### PR TITLE
Add device registry service and proxy integration

### DIFF
--- a/services/api-gateway/__tests__/server.test.js
+++ b/services/api-gateway/__tests__/server.test.js
@@ -1,12 +1,110 @@
+const express = require('express');
+const http = require('node:http');
 const request = require('supertest');
 const { createApp } = require('../src/server');
-const { topology } = require('../src/routes');
+
+function createDeviceRegistryStub() {
+  const app = express();
+  app.use(express.json());
+
+  const devices = new Map([
+    [
+      'device-thermostat-1',
+      {
+        id: 'device-thermostat-1',
+        roomId: 'room-1',
+        capabilities: ['thermostat'],
+        state: { temperature: 72 }
+      }
+    ]
+  ]);
+
+  app.get('/devices', (req, res) => {
+    res.json({ devices: Array.from(devices.values()) });
+  });
+
+  app.get('/devices/:id', (req, res) => {
+    const device = devices.get(req.params.id);
+    if (!device) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    res.json(device);
+  });
+
+  app.post('/devices', (req, res) => {
+    const payload = req.body || {};
+    if (!payload.id) {
+      res.status(400).json({ error: 'Missing id' });
+      return;
+    }
+    devices.set(payload.id, {
+      id: payload.id,
+      roomId: payload.roomId,
+      capabilities: payload.capabilities || [],
+      state: payload.state || {}
+    });
+    res.status(201).json(devices.get(payload.id));
+  });
+
+  app.put('/devices/:id', (req, res) => {
+    const existing = devices.get(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    const updates = req.body || {};
+    const updated = {
+      ...existing,
+      ...updates,
+      state: { ...existing.state, ...(updates.state || {}) }
+    };
+    devices.set(req.params.id, updated);
+    res.json(updated);
+  });
+
+  app.delete('/devices/:id', (req, res) => {
+    if (!devices.has(req.params.id)) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    devices.delete(req.params.id);
+    res.status(204).send();
+  });
+
+  app.post('/devices/:id/state', (req, res) => {
+    const existing = devices.get(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    existing.state = { ...existing.state, ...(req.body || {}) };
+    devices.set(req.params.id, existing);
+    res.json({ deviceId: existing.id, state: existing.state });
+  });
+
+  return { app, devices };
+}
 
 describe('api-gateway server', () => {
+  let registryServer;
   let app;
+  let devices;
 
-  beforeAll(() => {
-    app = createApp();
+  beforeAll((done) => {
+    const { app: registryApp, devices: registryDevices } = createDeviceRegistryStub();
+    devices = registryDevices;
+    registryServer = http.createServer(registryApp);
+    registryServer.listen(0, () => {
+      const { port } = registryServer.address();
+      const deviceRegistryUrl = `http://127.0.0.1:${port}`;
+      app = createApp({ config: { port: 0, tlsDisable: true, deviceRegistryUrl } });
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    registryServer.close(done);
   });
 
   describe('GET /healthz', () => {
@@ -17,11 +115,47 @@ describe('api-gateway server', () => {
     });
   });
 
-  describe('GET /v1/topology', () => {
-    it('returns deterministic topology data', async () => {
+  describe('device proxy routes', () => {
+    it('proxies CRUD operations to the device registry service', async () => {
+      const client = request(app);
+
+      const listResponse = await client.get('/v1/devices');
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.body.devices).toHaveLength(1);
+
+      const createResponse = await client
+        .post('/v1/devices')
+        .send({ id: 'device-light-1', roomId: 'room-1', capabilities: ['light'], state: { power: 'off' } });
+      expect(createResponse.status).toBe(201);
+      expect(devices.has('device-light-1')).toBe(true);
+
+      const updateResponse = await client
+        .put('/v1/devices/device-light-1')
+        .send({ roomId: 'room-2', state: { power: 'on' } });
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body).toMatchObject({ roomId: 'room-2', state: { power: 'on' } });
+
+      const stateResponse = await client
+        .post('/v1/devices/device-light-1/state')
+        .send({ brightness: 80 });
+      expect(stateResponse.status).toBe(200);
+      expect(stateResponse.body).toMatchObject({ deviceId: 'device-light-1', state: { power: 'on', brightness: 80 } });
+
+      const deleteResponse = await client.delete('/v1/devices/device-light-1');
+      expect(deleteResponse.status).toBe(204);
+      expect(devices.has('device-light-1')).toBe(false);
+    });
+
+    it('aggregates topology data from the device registry', async () => {
       const response = await request(app).get('/v1/topology');
       expect(response.status).toBe(200);
-      expect(response.body).toEqual(topology);
+      expect(response.body.devices).toHaveLength(devices.size);
+      expect(response.body.rooms).toEqual([
+        {
+          id: 'room-1',
+          deviceIds: Array.from(devices.values()).filter((device) => device.roomId === 'room-1').map((device) => device.id)
+        }
+      ]);
     });
   });
 });

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -17,7 +17,8 @@
   "author": "LokanOS",
   "license": "UNLICENSED",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "jest": "^30.1.3",

--- a/services/api-gateway/src/config.js
+++ b/services/api-gateway/src/config.js
@@ -1,4 +1,5 @@
 const DEFAULT_PORT = 8080;
+const DEFAULT_DEVICE_REGISTRY_URL = 'http://localhost:4100';
 
 function parsePort(rawPort) {
   const port = Number.parseInt(rawPort, 10);
@@ -16,14 +17,28 @@ function parseTlsDisable(rawValue) {
   return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
+function parseDeviceRegistryUrl(rawUrl) {
+  if (!rawUrl) {
+    return DEFAULT_DEVICE_REGISTRY_URL;
+  }
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.toString().replace(/\/$/, '');
+  } catch (error) {
+    return DEFAULT_DEVICE_REGISTRY_URL;
+  }
+}
+
 function getConfig(env = process.env) {
   return {
     port: parsePort(env.PORT),
-    tlsDisable: parseTlsDisable(env.TLS_DISABLE)
+    tlsDisable: parseTlsDisable(env.TLS_DISABLE),
+    deviceRegistryUrl: parseDeviceRegistryUrl(env.DEVICE_REGISTRY_URL)
   };
 }
 
 module.exports = {
   DEFAULT_PORT,
+  DEFAULT_DEVICE_REGISTRY_URL,
   getConfig
 };

--- a/services/api-gateway/src/server.js
+++ b/services/api-gateway/src/server.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const { registerRoutes } = require('./routes');
+const { getConfig } = require('./config');
 
-function createApp() {
+function createApp(options = {}) {
+  const resolvedConfig = options.config || getConfig();
   const app = express();
   app.use(express.json());
 
@@ -9,7 +11,9 @@ function createApp() {
     res.json({ status: 'ok' });
   });
 
-  registerRoutes(app);
+  registerRoutes(app, {
+    deviceRegistryUrl: resolvedConfig.deviceRegistryUrl
+  });
 
   app.use((req, res) => {
     res.status(404).json({ error: 'Not Found' });

--- a/services/device-registry/__tests__/registry.test.js
+++ b/services/device-registry/__tests__/registry.test.js
@@ -1,0 +1,111 @@
+const request = require('supertest');
+const { DeviceRegistry } = require('../src/registry');
+const { DeviceId } = require('../src/types');
+const { createRestApp } = require('../src/rest');
+
+describe('DeviceRegistry', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new DeviceRegistry();
+  });
+
+  it('creates, reads, updates, and deletes devices', () => {
+    const created = registry.createDevice({
+      id: 'device-1',
+      roomId: 'room-1',
+      capabilities: ['light'],
+      state: { power: 'off' }
+    });
+
+    expect(created).toMatchObject({
+      id: 'device-1',
+      roomId: 'room-1',
+      capabilities: ['light'],
+      state: { power: 'off' }
+    });
+
+    const fetched = registry.getDevice(new DeviceId('device-1'));
+    expect(fetched).toEqual(created);
+
+    const updated = registry.updateDevice('device-1', {
+      roomId: 'room-2',
+      capabilities: ['light', 'dimming'],
+      state: { power: 'on' }
+    });
+
+    expect(updated).toMatchObject({
+      id: 'device-1',
+      roomId: 'room-2',
+      capabilities: ['light', 'dimming'],
+      state: { power: 'on' }
+    });
+
+    const deleted = registry.deleteDevice('device-1');
+    expect(deleted).toBe(true);
+    expect(registry.getDevice('device-1')).toBeNull();
+  });
+
+  it('notifies subscribers on state updates', () => {
+    registry.createDevice({
+      id: 'device-1',
+      roomId: 'room-1',
+      capabilities: ['light'],
+      state: { power: 'off' }
+    });
+
+    const events = [];
+    const unsubscribe = registry.subscribeToStateUpdates((event) => {
+      events.push(event);
+    });
+
+    const event = registry.updateDeviceState('device-1', { power: 'on' });
+    expect(event).toEqual({
+      deviceId: 'device-1',
+      state: { power: 'on' }
+    });
+
+    unsubscribe();
+
+    expect(events).toEqual([
+      {
+        deviceId: 'device-1',
+        state: { power: 'on' }
+      }
+    ]);
+  });
+});
+
+describe('REST API', () => {
+  it('performs CRUD operations over HTTP', async () => {
+    const { app, registry } = createRestApp(new DeviceRegistry());
+    const client = request(app);
+
+    const createResponse = await client
+      .post('/devices')
+      .send({ id: 'device-1', roomId: 'room-1', capabilities: ['light'], state: { power: 'off' } });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body).toMatchObject({ id: 'device-1', roomId: 'room-1' });
+
+    const listResponse = await client.get('/devices');
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.devices).toHaveLength(1);
+
+    const updateResponse = await client
+      .put('/devices/device-1')
+      .send({ roomId: 'room-2', state: { power: 'on' } });
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body).toMatchObject({ roomId: 'room-2', state: { power: 'on' } });
+
+    const stateResponse = await client
+      .post('/devices/device-1/state')
+      .send({ brightness: 50 });
+    expect(stateResponse.status).toBe(200);
+    expect(stateResponse.body).toMatchObject({ deviceId: 'device-1', state: { power: 'on', brightness: 50 } });
+
+    const deleteResponse = await client.delete('/devices/device-1');
+    expect(deleteResponse.status).toBe(204);
+    expect(registry.getDevice('device-1')).toBeNull();
+  });
+});

--- a/services/device-registry/package-lock.json
+++ b/services/device-registry/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "@lokanos/api-gateway",
+  "name": "@lokanos/device-registry",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@lokanos/api-gateway",
+      "name": "@lokanos/device-registry",
       "version": "0.1.0",
-      "license": "UNLICENSED",
       "dependencies": {
-        "express": "^5.1.0",
-        "node-fetch": "^3.3.2"
+        "@grpc/grpc-js": "^1.9.13",
+        "@grpc/proto-loader": "^0.7.13",
+        "express": "^5.1.0"
       },
       "devDependencies": {
         "jest": "^30.1.3",
@@ -547,6 +547,55 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
+      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -984,6 +1033,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1043,6 +1102,70 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -1158,7 +1281,6 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
@@ -1510,7 +1632,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1905,7 +2026,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -1920,7 +2040,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1930,14 +2049,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -1952,7 +2069,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1965,7 +2081,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2001,7 +2116,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2014,7 +2128,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2113,15 +2226,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -2329,7 +2433,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2499,29 +2602,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2623,18 +2703,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -2716,7 +2784,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2994,7 +3061,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3836,6 +3902,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4052,44 +4130,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -4403,6 +4443,30 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4499,7 +4563,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5168,7 +5231,6 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5278,15 +5340,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -5424,7 +5477,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -5441,7 +5493,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -5460,7 +5511,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -5470,7 +5520,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5480,14 +5529,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5502,7 +5549,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/services/device-registry/package.json
+++ b/services/device-registry/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@lokanos/device-registry",
+  "version": "0.1.0",
+  "description": "In-memory device registry with REST and gRPC interfaces.",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/index.js",
+    "build": "node -e \"console.log('build step not required for device registry service')\"",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.9.13",
+    "@grpc/proto-loader": "^0.7.13",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "jest": "^30.1.3",
+    "supertest": "^7.1.4"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "collectCoverage": true,
+    "coverageProvider": "v8"
+  }
+}

--- a/services/device-registry/proto/device_registry.proto
+++ b/services/device-registry/proto/device_registry.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package lokanos.device_registry;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+message DeviceId {
+  string value = 1;
+}
+
+message Device {
+  string id = 1;
+  string room_id = 2;
+  repeated string capabilities = 3;
+  google.protobuf.Struct state = 4;
+}
+
+message DeviceList {
+  repeated Device devices = 1;
+}
+
+message UpdateDeviceStateRequest {
+  string device_id = 1;
+  google.protobuf.Struct state = 2;
+}
+
+message DeviceStateEvent {
+  string device_id = 1;
+  google.protobuf.Struct state = 2;
+}
+
+service DeviceRegistryService {
+  rpc ListDevices(google.protobuf.Empty) returns (DeviceList);
+  rpc GetDevice(DeviceId) returns (Device);
+  rpc CreateDevice(Device) returns (Device);
+  rpc UpdateDevice(Device) returns (Device);
+  rpc DeleteDevice(DeviceId) returns (google.protobuf.Empty);
+  rpc UpdateDeviceState(UpdateDeviceStateRequest) returns (DeviceStateEvent);
+  rpc SubscribeDeviceStates(google.protobuf.Empty) returns (stream DeviceStateEvent);
+}

--- a/services/device-registry/src/grpc.js
+++ b/services/device-registry/src/grpc.js
@@ -1,0 +1,121 @@
+const path = require('node:path');
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require('@grpc/proto-loader');
+const { DeviceRegistry } = require('./registry');
+
+const PROTO_PATH = path.join(__dirname, '..', 'proto', 'device_registry.proto');
+
+function loadProto() {
+  const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+    includeDirs: [path.join(__dirname, '..', 'proto')]
+  });
+  return grpc.loadPackageDefinition(packageDefinition).lokanos.device_registry;
+}
+
+function toStruct(value) {
+  return value;
+}
+
+function createGrpcServer(registry = new DeviceRegistry()) {
+  const proto = loadProto();
+  const server = new grpc.Server();
+
+  server.addService(proto.DeviceRegistryService.service, {
+    ListDevices: (call, callback) => {
+      callback(null, { devices: registry.listDevices().map(serializeDevice) });
+    },
+    GetDevice: (call, callback) => {
+      const device = registry.getDevice(call.request.value);
+      if (!device) {
+        callback({ code: grpc.status.NOT_FOUND, message: 'Device not found' });
+        return;
+      }
+      callback(null, serializeDevice(device));
+    },
+    CreateDevice: (call, callback) => {
+      try {
+        const device = registry.createDevice(deserializeDevice(call.request));
+        callback(null, serializeDevice(device));
+      } catch (error) {
+        callback({ code: grpc.status.INVALID_ARGUMENT, message: error.message });
+      }
+    },
+    UpdateDevice: (call, callback) => {
+      try {
+        const device = registry.updateDevice(call.request.id, deserializeDevice(call.request));
+        callback(null, serializeDevice(device));
+      } catch (error) {
+        const code = error.message.includes('not found') ? grpc.status.NOT_FOUND : grpc.status.INVALID_ARGUMENT;
+        callback({ code, message: error.message });
+      }
+    },
+    DeleteDevice: (call, callback) => {
+      const deleted = registry.deleteDevice(call.request.value);
+      if (!deleted) {
+        callback({ code: grpc.status.NOT_FOUND, message: 'Device not found' });
+        return;
+      }
+      callback(null, {});
+    },
+    UpdateDeviceState: (call, callback) => {
+      try {
+        const event = registry.updateDeviceState(call.request.device_id, call.request.state || {});
+        callback(null, serializeStateEvent(event));
+      } catch (error) {
+        const code = error.message.includes('not found') ? grpc.status.NOT_FOUND : grpc.status.INVALID_ARGUMENT;
+        callback({ code, message: error.message });
+      }
+    },
+    SubscribeDeviceStates: (call) => {
+      const sendEvent = (event) => {
+        call.write(serializeStateEvent(event));
+      };
+
+      const unsubscribe = registry.subscribeToStateUpdates(sendEvent);
+      call.on('cancelled', () => {
+        unsubscribe();
+      });
+      call.on('end', () => {
+        unsubscribe();
+        call.end();
+      });
+    }
+  });
+
+  return { server, proto };
+}
+
+function serializeDevice(device) {
+  return {
+    id: device.id,
+    room_id: device.roomId,
+    capabilities: device.capabilities,
+    state: toStruct(device.state)
+  };
+}
+
+function deserializeDevice(message) {
+  return {
+    id: message.id,
+    roomId: message.room_id,
+    capabilities: Array.isArray(message.capabilities) ? message.capabilities : [],
+    state: message.state || {}
+  };
+}
+
+function serializeStateEvent(event) {
+  return {
+    device_id: event.deviceId,
+    state: toStruct(event.state)
+  };
+}
+
+module.exports = {
+  createGrpcServer,
+  loadProto
+};

--- a/services/device-registry/src/index.js
+++ b/services/device-registry/src/index.js
@@ -1,0 +1,57 @@
+const http = require('node:http');
+const grpc = require('@grpc/grpc-js');
+const { createRestApp } = require('./rest');
+const { createGrpcServer } = require('./grpc');
+const { DeviceRegistry } = require('./registry');
+
+const REST_PORT = Number.parseInt(process.env.REST_PORT || '4100', 10);
+const GRPC_PORT = Number.parseInt(process.env.GRPC_PORT || '50051', 10);
+
+function startServers() {
+  const registry = new DeviceRegistry([
+    {
+      id: 'device-thermostat-1',
+      roomId: 'room-1',
+      capabilities: ['thermostat', 'temperature'],
+      state: { temperature: 72 }
+    },
+    {
+      id: 'device-light-1',
+      roomId: 'room-1',
+      capabilities: ['light', 'dimming'],
+      state: { power: 'on', brightness: 80 }
+    },
+    {
+      id: 'device-light-2',
+      roomId: 'room-2',
+      capabilities: ['light'],
+      state: { power: 'off' }
+    }
+  ]);
+
+  const { app } = createRestApp(registry);
+  const restServer = http.createServer(app);
+  restServer.listen(REST_PORT, () => {
+    console.log(`Device registry REST API listening on port ${REST_PORT}`);
+  });
+
+  const { server: grpcServer } = createGrpcServer(registry);
+  grpcServer.bindAsync(`0.0.0.0:${GRPC_PORT}`, grpc.ServerCredentials.createInsecure(), (err) => {
+    if (err) {
+      console.error('Failed to start gRPC server:', err);
+      process.exit(1);
+    }
+    grpcServer.start();
+    console.log(`Device registry gRPC API listening on port ${GRPC_PORT}`);
+  });
+
+  return { restServer, grpcServer, registry };
+}
+
+if (require.main === module) {
+  startServers();
+}
+
+module.exports = {
+  startServers
+};

--- a/services/device-registry/src/registry.js
+++ b/services/device-registry/src/registry.js
@@ -1,0 +1,104 @@
+const { EventEmitter } = require('events');
+const { DeviceId, RoomId, Capability, DeviceState } = require('./types');
+
+class DeviceRegistry {
+  constructor(initialDevices = []) {
+    this.devices = new Map();
+    this.emitter = new EventEmitter();
+    this.emitter.setMaxListeners(0);
+
+    initialDevices.forEach((device) => {
+      this.createDevice(device);
+    });
+  }
+
+  normalizeDevicePayload(payload) {
+    if (!payload || typeof payload !== 'object') {
+      throw new TypeError('Device payload must be an object');
+    }
+
+    const id = payload.id instanceof DeviceId ? payload.id.toString() : new DeviceId(payload.id).toString();
+    const roomId = payload.roomId instanceof RoomId ? payload.roomId.toString() : new RoomId(payload.roomId).toString();
+    const capabilities = Array.isArray(payload.capabilities)
+      ? payload.capabilities.map((cap) => (cap instanceof Capability ? cap.toString() : new Capability(cap).toString()))
+      : [];
+    const state = payload.state instanceof DeviceState ? payload.state.toJSON() : new DeviceState(payload.state || {}).toJSON();
+
+    return {
+      id,
+      roomId,
+      capabilities,
+      state
+    };
+  }
+
+  listDevices() {
+    return Array.from(this.devices.values()).map((device) => ({ ...device, state: { ...device.state } }));
+  }
+
+  getDevice(deviceId) {
+    const id = deviceId instanceof DeviceId ? deviceId.toString() : new DeviceId(deviceId).toString();
+    const device = this.devices.get(id);
+    if (!device) {
+      return null;
+    }
+    return { ...device, state: { ...device.state } };
+  }
+
+  createDevice(payload) {
+    const normalized = this.normalizeDevicePayload(payload);
+    if (this.devices.has(normalized.id)) {
+      throw new Error(`Device ${normalized.id} already exists`);
+    }
+    this.devices.set(normalized.id, normalized);
+    return { ...normalized, state: { ...normalized.state } };
+  }
+
+  updateDevice(deviceId, updates) {
+    const existing = this.getDevice(deviceId);
+    if (!existing) {
+      throw new Error(`Device ${deviceId} not found`);
+    }
+    const merged = this.normalizeDevicePayload({
+      id: existing.id,
+      roomId: updates.roomId ?? existing.roomId,
+      capabilities: updates.capabilities ?? existing.capabilities,
+      state: updates.state ? { ...existing.state, ...updates.state } : existing.state
+    });
+    this.devices.set(merged.id, merged);
+    return { ...merged, state: { ...merged.state } };
+  }
+
+  deleteDevice(deviceId) {
+    const id = deviceId instanceof DeviceId ? deviceId.toString() : new DeviceId(deviceId).toString();
+    const existed = this.devices.delete(id);
+    return existed;
+  }
+
+  updateDeviceState(deviceId, stateUpdate) {
+    const existing = this.getDevice(deviceId);
+    if (!existing) {
+      throw new Error(`Device ${deviceId} not found`);
+    }
+    const currentState = new DeviceState(existing.state);
+    const mergedState = currentState.merge(stateUpdate);
+    const updated = { ...existing, state: mergedState };
+    this.devices.set(existing.id, { ...existing, state: mergedState });
+
+    const event = {
+      deviceId: existing.id,
+      state: { ...mergedState }
+    };
+    this.emitter.emit('state', event);
+    return event;
+  }
+
+  subscribeToStateUpdates(listener) {
+    this.emitter.on('state', listener);
+    return () => this.emitter.off('state', listener);
+  }
+}
+
+module.exports = {
+  DeviceRegistry
+};

--- a/services/device-registry/src/rest.js
+++ b/services/device-registry/src/rest.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const { DeviceRegistry } = require('./registry');
+
+function createRestApp(registry = new DeviceRegistry()) {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/healthz', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.get('/devices', (req, res) => {
+    res.json({ devices: registry.listDevices() });
+  });
+
+  app.get('/devices/:id', (req, res) => {
+    const device = registry.getDevice(req.params.id);
+    if (!device) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    res.json(device);
+  });
+
+  app.post('/devices', (req, res) => {
+    try {
+      const device = registry.createDevice(req.body);
+      res.status(201).json(device);
+    } catch (error) {
+      res.status(400).json({ error: error.message });
+    }
+  });
+
+  app.put('/devices/:id', (req, res) => {
+    try {
+      const device = registry.updateDevice(req.params.id, req.body || {});
+      res.json(device);
+    } catch (error) {
+      if (error.message.includes('not found')) {
+        res.status(404).json({ error: error.message });
+      } else {
+        res.status(400).json({ error: error.message });
+      }
+    }
+  });
+
+  app.delete('/devices/:id', (req, res) => {
+    const deleted = registry.deleteDevice(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    res.status(204).send();
+  });
+
+  app.post('/devices/:id/state', (req, res) => {
+    try {
+      const event = registry.updateDeviceState(req.params.id, req.body || {});
+      res.json(event);
+    } catch (error) {
+      if (error.message.includes('not found')) {
+        res.status(404).json({ error: error.message });
+      } else {
+        res.status(400).json({ error: error.message });
+      }
+    }
+  });
+
+  app.get('/devices/state/stream', (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+
+    const sendEvent = (event) => {
+      res.write(`event: device-state\n`);
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+
+    const unsubscribe = registry.subscribeToStateUpdates(sendEvent);
+    req.on('close', () => {
+      unsubscribe();
+    });
+  });
+
+  app.use((req, res) => {
+    res.status(404).json({ error: 'Not Found' });
+  });
+
+  return { app, registry };
+}
+
+module.exports = {
+  createRestApp
+};

--- a/services/device-registry/src/types.js
+++ b/services/device-registry/src/types.js
@@ -1,0 +1,70 @@
+class DeviceId {
+  constructor(value) {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new TypeError('DeviceId must be a non-empty string');
+    }
+    this.value = value;
+  }
+
+  toString() {
+    return this.value;
+  }
+}
+
+class RoomId {
+  constructor(value) {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new TypeError('RoomId must be a non-empty string');
+    }
+    this.value = value;
+  }
+
+  toString() {
+    return this.value;
+  }
+}
+
+class Capability {
+  constructor(value) {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new TypeError('Capability must be a non-empty string');
+    }
+    this.value = value;
+  }
+
+  toString() {
+    return this.value;
+  }
+}
+
+class DeviceState {
+  constructor(initialState = {}) {
+    if (!DeviceState.isValid(initialState)) {
+      throw new TypeError('DeviceState must be a plain object');
+    }
+    this.value = { ...initialState };
+  }
+
+  static isValid(state) {
+    return state && typeof state === 'object' && !Array.isArray(state);
+  }
+
+  merge(update) {
+    if (!DeviceState.isValid(update)) {
+      throw new TypeError('DeviceState updates must be plain objects');
+    }
+    this.value = { ...this.value, ...update };
+    return this.value;
+  }
+
+  toJSON() {
+    return { ...this.value };
+  }
+}
+
+module.exports = {
+  DeviceId,
+  RoomId,
+  Capability,
+  DeviceState
+};


### PR DESCRIPTION
## Summary
- add a standalone device-registry service with in-memory CRUD, REST, and gRPC interfaces plus state change pub/sub
- define device value-object types and gRPC schema to expose registry operations and streaming state updates
- integrate the API gateway with the device registry REST API and extend tests to cover proxied CRUD/topology flows

## Testing
- npm test --prefix services/api-gateway
- npm test --prefix services/device-registry

------
https://chatgpt.com/codex/tasks/task_e_68d4bf950f4c832f95cfd568fdc1ba4c