### PR TITLE
feat: introduce core messaging and config scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,10 +32,47 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "common-config",
+ "common-mdns",
+ "common-msgbus",
  "common-obs",
+ "serde",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3bdd6ea595b2ea504500a3566071beb81125fc15d40a6f6bffa43575f64152"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "portable-atomic",
+ "rand",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "tryhard",
+ "url",
 ]
 
 [[package]]
@@ -66,6 +103,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -138,16 +181,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -164,9 +241,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-ble"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "common-config"
 version = "0.1.0"
 dependencies = [
+ "dotenvy",
+ "envy",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "common-mdns"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -174,8 +272,14 @@ dependencies = [
 name = "common-msgbus"
 version = "0.1.0"
 dependencies = [
+ "async-nats",
+ "async-trait",
+ "dashmap",
+ "futures",
  "serde",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -186,6 +290,113 @@ dependencies = [
  "axum",
  "serde_json",
  "tracing",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -201,6 +412,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
+
+[[package]]
 name = "energy-svc"
 version = "0.1.0"
 dependencies = [
@@ -211,6 +471,27 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fnv"
@@ -228,12 +509,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -241,6 +538,40 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -254,10 +585,37 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -265,6 +623,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "http"
@@ -350,6 +714,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +848,22 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -432,6 +919,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom",
+ "log",
+ "rand",
+ "signatory",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +941,21 @@ checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "object"
@@ -454,6 +971,34 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -472,6 +1017,46 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "presence-svc"
@@ -509,10 +1094,64 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "common-config",
+ "common-mdns",
+ "common-msgbus",
  "common-obs",
+ "serde",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -533,6 +1172,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rule-engine"
 version = "0.1.0"
 dependencies = [
@@ -549,6 +1202,82 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.6",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -573,6 +1302,50 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -618,6 +1391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +1408,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -641,12 +1434,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -672,6 +1504,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +1541,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "telemetry-pipe"
@@ -730,12 +1595,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "bytes",
  "io-uring",
  "libc",
  "mio",
@@ -755,6 +1662,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -848,10 +1789,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "updater"
@@ -866,16 +1829,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -893,6 +1886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -958,3 +1960,113 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = [
     "crates/common-auth",
     "crates/common-config",
     "crates/common-msgbus",
+    "crates/common-mdns",
+    "crates/common-ble",
     "crates/common-obs",
     "services/api-gateway",
     "services/device-registry",
@@ -24,6 +26,9 @@ license = "Apache-2.0"
 [workspace.dependencies]
 axum = "0.7"
 common-config = { path = "crates/common-config" }
+common-msgbus = { path = "crates/common-msgbus" }
+common-mdns = { path = "crates/common-mdns" }
+common-ble = { path = "crates/common-ble" }
 common-obs = { path = "crates/common-obs" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/common-ble/Cargo.toml
+++ b/crates/common-ble/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "common-ble"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/common-ble/src/lib.rs
+++ b/crates/common-ble/src/lib.rs
@@ -1,0 +1,107 @@
+//! BLE commissioning shim definitions used across platform services.
+
+use serde::{Deserialize, Serialize};
+
+/// Request issued by a device to generate a certificate signing request (CSR).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CsrRequest {
+    /// Globally unique identifier for the requesting device.
+    pub device_id: String,
+    /// Binary CSR payload (DER encoded) represented as base64 in transit.
+    pub csr: String,
+    /// Optional nonce to bind the CSR to a commissioning session.
+    #[serde(default)]
+    pub nonce: Option<String>,
+}
+
+impl Default for CsrRequest {
+    fn default() -> Self {
+        Self {
+            device_id: String::new(),
+            csr: String::new(),
+            nonce: None,
+        }
+    }
+}
+
+/// Response returned after the CSR is processed by the platform.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CsrResponse {
+    /// Base64-encoded device certificate.
+    pub certificate: String,
+    /// Optional trust anchor identifier that signed the certificate.
+    #[serde(default)]
+    pub ca_identifier: Option<String>,
+}
+
+impl Default for CsrResponse {
+    fn default() -> Self {
+        Self {
+            certificate: String::new(),
+            ca_identifier: None,
+        }
+    }
+}
+
+/// Verification payload sent once the device applied the commissioned credentials.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyRequest {
+    /// Device identifier performing verification.
+    pub device_id: String,
+    /// Signature covering the attestation challenge.
+    pub signature: String,
+    /// Optional opaque session identifier.
+    #[serde(default)]
+    pub session: Option<String>,
+}
+
+impl Default for VerifyRequest {
+    fn default() -> Self {
+        Self {
+            device_id: String::new(),
+            signature: String::new(),
+            session: None,
+        }
+    }
+}
+
+/// Verification response returned to the device.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyResponse {
+    /// Whether the verification succeeded.
+    pub accepted: bool,
+    /// Optional textual reason for rejection.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl Default for VerifyResponse {
+    fn default() -> Self {
+        Self {
+            accepted: false,
+            reason: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_serialization() {
+        let request = CsrRequest {
+            device_id: "device-123".into(),
+            csr: "YmFzZTY0IGNzciBieXRlcw==".into(),
+            nonce: Some("abc123".into()),
+        };
+        let json = serde_json::to_string(&request).expect("serialize");
+        assert!(json.contains("deviceId"));
+        let decoded: CsrRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(request, decoded);
+    }
+}

--- a/crates/common-config/src/lib.rs
+++ b/crates/common-config/src/lib.rs
@@ -1,6 +1,124 @@
 //! Shared configuration helpers for LokanOS services.
 
 use std::env;
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Attempt to load variables from a local `.env` file while keeping real environment
+/// overrides intact.
+fn load_dotenv() {
+    match dotenvy::dotenv() {
+        Ok(path) => tracing::debug!(?path, "loaded dotenv file"),
+        Err(dotenvy::Error::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            tracing::trace!("no .env file found")
+        }
+        Err(error) => tracing::warn!(%error, "failed to parse .env file"),
+    }
+}
+
+/// Errors that may occur while loading service configuration.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Wrapper around deserialization failures.
+    #[error("failed to deserialize configuration from environment: {0}")]
+    Deserialize(#[from] envy::Error),
+}
+
+/// Trait implemented by strongly typed configuration structs for services.
+pub trait ServiceConfig: DeserializeOwned + Default {
+    /// Environment variable prefix used to load the configuration.
+    const PREFIX: &'static str;
+
+    /// Allow implementors to tweak values after environment loading.
+    fn apply_environment_overrides(&mut self, _prefix: &str) {}
+}
+
+/// Load a strongly typed configuration struct for a service using its declared prefix.
+pub fn load<T>() -> Result<T, ConfigError>
+where
+    T: ServiceConfig,
+{
+    let mut config = load_with_prefix::<T>(T::PREFIX)?;
+    config.apply_environment_overrides(T::PREFIX);
+    Ok(config)
+}
+
+/// Load a configuration struct using the provided environment prefix.
+pub fn load_with_prefix<T>(prefix: &str) -> Result<T, ConfigError>
+where
+    T: DeserializeOwned + Default,
+{
+    load_dotenv();
+
+    if prefix.is_empty() {
+        envy::from_env::<T>().map_err(ConfigError::from)
+    } else {
+        let vars = env::vars().filter_map(|(key, value)| {
+            key.strip_prefix(prefix)
+                .map(|stripped| (stripped.to_string(), value))
+        });
+        envy::from_iter(vars).map_err(ConfigError::from)
+    }
+}
+
+/// Common configuration shared across services for connecting to the message bus.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct MsgBusConfig {
+    /// Connection URL for the message bus backend.
+    pub url: String,
+    /// Timeout (in milliseconds) for request/response flows.
+    pub request_timeout_ms: u64,
+}
+
+impl Default for MsgBusConfig {
+    fn default() -> Self {
+        Self {
+            url: "nats://127.0.0.1:4222".to_string(),
+            request_timeout_ms: 2_000,
+        }
+    }
+}
+
+impl MsgBusConfig {
+    /// Timeout for bus requests as a [`Duration`].
+    pub fn request_timeout(&self) -> Duration {
+        Duration::from_millis(self.request_timeout_ms)
+    }
+
+    /// Overlay environment-driven overrides onto the existing configuration.
+    pub fn apply_environment_overrides(&mut self, prefix: &str) {
+        if let Some(url) = env_value(prefix, &["BUS__URL", "BUS_URL"]) {
+            self.url = url;
+        }
+
+        if let Some(timeout) = env_value(
+            prefix,
+            &["BUS__REQUEST_TIMEOUT_MS", "BUS_REQUEST_TIMEOUT_MS"],
+        ) {
+            match timeout.parse::<u64>() {
+                Ok(value) => self.request_timeout_ms = value,
+                Err(error) => tracing::warn!(%timeout, %error, "invalid bus timeout override"),
+            }
+        }
+    }
+}
+
+fn env_value(prefix: &str, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .filter_map(|suffix| {
+            if prefix.is_empty() {
+                env::var(suffix).ok()
+            } else {
+                let key = format!("{prefix}{suffix}");
+                env::var(key).ok()
+            }
+        })
+        .next()
+}
 
 /// Resolve the port for a service from an environment variable.
 ///
@@ -15,5 +133,57 @@ pub fn service_port(var: &str, default: u16) -> u16 {
             })
             .unwrap_or(default),
         Err(_) => default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load, MsgBusConfig, ServiceConfig};
+
+    #[derive(Debug, Clone, serde::Deserialize, PartialEq)]
+    #[serde(default)]
+    struct TestConfig {
+        value: String,
+        number: u16,
+        bus: MsgBusConfig,
+    }
+
+    impl Default for TestConfig {
+        fn default() -> Self {
+            Self {
+                value: "default".to_string(),
+                number: 10,
+                bus: MsgBusConfig::default(),
+            }
+        }
+    }
+
+    #[test]
+    fn env_overrides_dotenv_and_defaults() {
+        std::env::remove_var("TEST_VALUE");
+        std::env::remove_var("TEST_NUMBER");
+        std::env::remove_var("TEST_BUS__URL");
+
+        // Simulate values that would normally come from the `.env` file.
+        std::env::set_var("TEST_VALUE", "from_dotenv");
+        std::env::set_var("TEST_BUS__URL", "nats://embedded");
+        std::env::set_var("TEST_BUS_URL", "nats://embedded");
+
+        // Explicit environment variables should take precedence.
+        std::env::set_var("TEST_VALUE", "from_env");
+        std::env::set_var("TEST_NUMBER", "42");
+
+        let config: TestConfig = load().expect("load config");
+        assert_eq!(config.value, "from_env");
+        assert_eq!(config.number, 42);
+        assert_eq!(config.bus.url, "nats://embedded");
+    }
+
+    impl ServiceConfig for TestConfig {
+        const PREFIX: &'static str = "TEST_";
+
+        fn apply_environment_overrides(&mut self, prefix: &str) {
+            self.bus.apply_environment_overrides(prefix);
+        }
     }
 }

--- a/crates/common-mdns/Cargo.toml
+++ b/crates/common-mdns/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "common-config"
+name = "common-mdns"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dotenvy = "0.15"
-envy = "0.4"
-serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/common-mdns/src/lib.rs
+++ b/crates/common-mdns/src/lib.rs
@@ -1,0 +1,66 @@
+//! Minimal mDNS announcer stub used during early development.
+
+use thiserror::Error;
+
+/// Errors returned by the announcer stub.
+#[derive(Debug, Error)]
+pub enum MdnsError {
+    /// Placeholder error for when an announcement cannot be created.
+    #[error("failed to announce service over mDNS: {0}")]
+    Announcement(String),
+}
+
+/// Handle returned when announcing a service.
+#[derive(Debug, Clone)]
+pub struct Announcement {
+    service: String,
+    port: u16,
+}
+
+impl Announcement {
+    /// Service label that was advertised.
+    pub fn service(&self) -> &str {
+        &self.service
+    }
+
+    /// TCP port that was advertised.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Stop advertising the service.
+    pub async fn shutdown(self) -> Result<(), MdnsError> {
+        tracing::info!(service = %self.service, port = self.port, "stopping mDNS announcement (stub)");
+        Ok(())
+    }
+}
+
+/// Announce a TCP service via mDNS.
+///
+/// This is currently a stub implementation that only emits structured logs.
+pub async fn announce(service: &str, port: u16) -> Result<Announcement, MdnsError> {
+    if service.is_empty() {
+        return Err(MdnsError::Announcement(
+            "service name must not be empty".into(),
+        ));
+    }
+
+    tracing::info!(service, port, "starting mDNS announcement (stub)");
+    Ok(Announcement {
+        service: service.to_string(),
+        port,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn announce_returns_handle() {
+        let handle = announce("_lokan._tcp", 1234).await.expect("announcement");
+        assert_eq!(handle.service(), "_lokan._tcp");
+        assert_eq!(handle.port(), 1234);
+        handle.shutdown().await.expect("shutdown");
+    }
+}

--- a/crates/common-msgbus/Cargo.toml
+++ b/crates/common-msgbus/Cargo.toml
@@ -4,10 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
+futures = "0.3"
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
+tokio-stream = { version = "0.1", optional = true }
 tracing = { workspace = true }
+dashmap = { version = "5", optional = true }
 
 [features]
-default = []
+default = ["nats"]
 json = ["serde"]
+mock = ["dashmap", "tokio-stream"]
+nats = ["async-nats", "tokio-stream"]
+
+[dependencies.async-nats]
+optional = true
+version = "0.37"

--- a/crates/common-msgbus/src/lib.rs
+++ b/crates/common-msgbus/src/lib.rs
@@ -1,27 +1,375 @@
 //! Message bus abstractions shared across services.
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use async_trait::async_trait;
+use futures::Stream;
 use thiserror::Error;
+use tokio::time::Duration;
+
+/// Represents a message that traveled across the bus.
+#[derive(Debug, Clone)]
+pub struct BusMessage {
+    /// Subject/topic the message was published on.
+    pub subject: String,
+    /// Message payload bytes.
+    pub payload: Vec<u8>,
+    /// Optional reply subject to send a response to.
+    pub reply: Option<String>,
+}
+
+impl BusMessage {
+    /// Convenience helper to respond to a request using the provided bus instance.
+    pub async fn respond<B: MessageBus + ?Sized>(
+        &self,
+        bus: &B,
+        payload: &[u8],
+    ) -> Result<(), MsgBusError> {
+        if let Some(reply) = &self.reply {
+            bus.respond(reply, payload).await
+        } else {
+            Err(MsgBusError::MissingReplySubject)
+        }
+    }
+}
+
+/// Stream of [`BusMessage`] items for a given subscription.
+pub struct Subscription {
+    subject: String,
+    inner: Pin<Box<dyn Stream<Item = BusMessage> + Send>>, // boxed stream for dynamic dispatch
+}
+
+impl Subscription {
+    fn new<S>(subject: String, stream: S) -> Self
+    where
+        S: Stream<Item = BusMessage> + Send + 'static,
+    {
+        Self {
+            subject,
+            inner: Box::pin(stream),
+        }
+    }
+
+    /// Subject this subscription listens on.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+}
+
+impl Stream for Subscription {
+    type Item = BusMessage;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // SAFETY: `inner` is pinned inside the struct and never moved after construction.
+        unsafe {
+            let inner = self.map_unchecked_mut(|me| &mut me.inner);
+            inner.poll_next(cx)
+        }
+    }
+}
 
 /// Errors that can occur while interacting with the message bus layer.
 #[derive(Debug, Error)]
 pub enum MsgBusError {
-    /// Stub error variant for unimplemented operations.
-    #[error("message bus operation not implemented")]
-    NotImplemented,
+    /// Underlying client failed to connect to the server.
+    #[error("unable to connect to message bus: {0}")]
+    Connection(String),
+    /// A publish operation failed.
+    #[error("unable to publish message: {0}")]
+    Publish(String),
+    /// A subscribe operation failed.
+    #[error("unable to create subscription: {0}")]
+    Subscribe(String),
+    /// Request/response exchange failed.
+    #[error("request failed: {0}")]
+    Request(String),
+    /// Request timed out waiting for a response.
+    #[error("request timed out after {0:?}")]
+    RequestTimeout(Duration),
+    /// Attempted to respond to a message that lacked a reply subject.
+    #[error("message did not include a reply subject")]
+    MissingReplySubject,
+    /// Attempted to reply to an unknown subject.
+    #[error("no pending request for reply subject {0}")]
+    UnknownReplySubject(String),
 }
 
-/// Represents a message published onto the platform bus.
-#[derive(Debug, Clone)]
-pub struct BusMessage {
-    pub topic: String,
-    pub payload: Vec<u8>,
+/// Abstraction over the platform message bus backend.
+#[async_trait]
+pub trait MessageBus: Send + Sync {
+    /// Publish `payload` to the given `subject`.
+    async fn publish(&self, subject: &str, payload: &[u8]) -> Result<(), MsgBusError>;
+
+    /// Subscribe to the given `subject`, returning a stream of [`BusMessage`].
+    async fn subscribe(&self, subject: &str) -> Result<Subscription, MsgBusError>;
+
+    /// Send a request and wait for the response.
+    async fn request(&self, subject: &str, payload: &[u8]) -> Result<BusMessage, MsgBusError>;
+
+    /// Respond to a request using the provided reply subject.
+    async fn respond(&self, reply_to: &str, payload: &[u8]) -> Result<(), MsgBusError>;
 }
 
-/// Publish a message to the shared bus.
-///
-/// Stub implementation that only logs the outgoing event.
-#[allow(unused_variables)]
-pub fn publish(message: &BusMessage) -> Result<(), MsgBusError> {
-    tracing::info!(topic = %message.topic, payload_len = message.payload.len(), "publishing stub message");
-    Ok(())
+#[cfg(feature = "nats")]
+mod nats_impl {
+    use super::{BusMessage, MessageBus, MsgBusError, Subscription};
+    use async_trait::async_trait;
+    use futures::StreamExt;
+    use tokio::time::{timeout, Duration};
+
+    /// Configuration for establishing a NATS-backed message bus connection.
+    #[derive(Debug, Clone)]
+    pub struct NatsConfig {
+        /// URL pointing to the NATS server instance.
+        pub url: String,
+        /// How long to wait for request/response exchanges.
+        pub request_timeout: Duration,
+    }
+
+    impl Default for NatsConfig {
+        fn default() -> Self {
+            Self {
+                url: "nats://127.0.0.1:4222".to_string(),
+                request_timeout: Duration::from_secs(2),
+            }
+        }
+    }
+
+    /// Wrapper around an [`async_nats::Client`] implementing [`MessageBus`].
+    #[derive(Clone)]
+    pub struct NatsBus {
+        client: async_nats::Client,
+        request_timeout: Duration,
+    }
+
+    impl NatsBus {
+        /// Establish a new connection to the configured NATS endpoint.
+        pub async fn connect(config: NatsConfig) -> Result<Self, MsgBusError> {
+            let client = async_nats::connect(config.url.clone())
+                .await
+                .map_err(|err| MsgBusError::Connection(err.to_string()))?;
+            Ok(Self {
+                client,
+                request_timeout: config.request_timeout,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl MessageBus for NatsBus {
+        async fn publish(&self, subject: &str, payload: &[u8]) -> Result<(), MsgBusError> {
+            self.client
+                .publish(subject.to_string(), payload.to_vec().into())
+                .await
+                .map_err(|err| MsgBusError::Publish(err.to_string()))
+        }
+
+        async fn subscribe(&self, subject: &str) -> Result<Subscription, MsgBusError> {
+            let subject_str = subject.to_string();
+            let subscriber = self
+                .client
+                .subscribe(subject_str.clone())
+                .await
+                .map_err(|err| MsgBusError::Subscribe(err.to_string()))?;
+
+            let stream = subscriber.map(|message| BusMessage {
+                subject: message.subject.to_string(),
+                payload: message.payload.to_vec(),
+                reply: message.reply.map(|subject| subject.to_string()),
+            });
+            Ok(Subscription::new(subject_str, stream))
+        }
+
+        async fn request(&self, subject: &str, payload: &[u8]) -> Result<BusMessage, MsgBusError> {
+            let response = timeout(
+                self.request_timeout,
+                self.client
+                    .request(subject.to_string(), payload.to_vec().into()),
+            )
+            .await
+            .map_err(|_| MsgBusError::RequestTimeout(self.request_timeout))
+            .and_then(|result| result.map_err(|err| MsgBusError::Request(err.to_string())))?;
+
+            Ok(BusMessage {
+                subject: response.subject.to_string(),
+                payload: response.payload.to_vec(),
+                reply: response.reply.map(|subject| subject.to_string()),
+            })
+        }
+
+        async fn respond(&self, reply_to: &str, payload: &[u8]) -> Result<(), MsgBusError> {
+            self.client
+                .publish(reply_to.to_string(), payload.to_vec().into())
+                .await
+                .map_err(|err| MsgBusError::Publish(err.to_string()))
+        }
+    }
+
+    pub use NatsBus as Client;
+    pub use NatsConfig as Config;
+}
+
+#[cfg(feature = "nats")]
+pub use nats_impl::{Client as NatsBus, Config as NatsConfig};
+
+#[cfg(feature = "mock")]
+mod mock_impl {
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    };
+
+    use async_trait::async_trait;
+    use dashmap::DashMap;
+    use futures::StreamExt;
+    use tokio::sync::{broadcast, oneshot};
+    use tokio_stream::wrappers::BroadcastStream;
+
+    use super::{BusMessage, MessageBus, MsgBusError, Subscription};
+
+    const CHANNEL_CAPACITY: usize = 64;
+
+    fn ensure_subject(
+        map: &DashMap<String, broadcast::Sender<BusMessage>>,
+        subject: &str,
+    ) -> broadcast::Sender<BusMessage> {
+        if let Some(existing) = map.get(subject) {
+            existing.clone()
+        } else {
+            let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
+            match map.entry(subject.to_string()) {
+                dashmap::mapref::entry::Entry::Occupied(entry) => entry.get().clone(),
+                dashmap::mapref::entry::Entry::Vacant(entry) => entry.insert(tx).clone(),
+            }
+        }
+    }
+
+    /// In-process mock message bus used for unit/integration tests.
+    #[derive(Clone, Default)]
+    pub struct MockBus {
+        subjects: Arc<DashMap<String, broadcast::Sender<BusMessage>>>,
+        pending: Arc<DashMap<String, oneshot::Sender<Vec<u8>>>>,
+        request_counter: Arc<AtomicU64>,
+    }
+
+    impl MockBus {
+        /// Create a new instance of the mock bus.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        fn next_reply_subject(&self) -> String {
+            let id = self.request_counter.fetch_add(1, Ordering::Relaxed);
+            format!("inproc.reply.{}", id)
+        }
+    }
+
+    #[async_trait]
+    impl MessageBus for MockBus {
+        async fn publish(&self, subject: &str, payload: &[u8]) -> Result<(), MsgBusError> {
+            let sender = ensure_subject(&self.subjects, subject);
+            let message = BusMessage {
+                subject: subject.to_string(),
+                payload: payload.to_vec(),
+                reply: None,
+            };
+            sender
+                .send(message)
+                .map(|_| ())
+                .map_err(|err| MsgBusError::Publish(err.to_string()))
+        }
+
+        async fn subscribe(&self, subject: &str) -> Result<Subscription, MsgBusError> {
+            let sender = ensure_subject(&self.subjects, subject);
+            let receiver = sender.subscribe();
+            let subject_string = subject.to_string();
+            let stream = BroadcastStream::new(receiver).filter_map(|item| match item {
+                Ok(message) => Some(message),
+                Err(broadcast::error::RecvError::Lagged(_)) => None,
+                Err(_) => None,
+            });
+            Ok(Subscription::new(subject_string, stream))
+        }
+
+        async fn request(&self, subject: &str, payload: &[u8]) -> Result<BusMessage, MsgBusError> {
+            let (tx, rx) = oneshot::channel();
+            let reply_subject = self.next_reply_subject();
+            self.pending.insert(reply_subject.clone(), tx);
+
+            let sender = ensure_subject(&self.subjects, subject);
+            let message = BusMessage {
+                subject: subject.to_string(),
+                payload: payload.to_vec(),
+                reply: Some(reply_subject.clone()),
+            };
+            sender
+                .send(message)
+                .map_err(|err| MsgBusError::Request(err.to_string()))?;
+
+            let payload = rx
+                .await
+                .map_err(|err| MsgBusError::Request(err.to_string()))?;
+
+            Ok(BusMessage {
+                subject: reply_subject,
+                payload,
+                reply: None,
+            })
+        }
+
+        async fn respond(&self, reply_to: &str, payload: &[u8]) -> Result<(), MsgBusError> {
+            if let Some((_, waiter)) = self.pending.remove(reply_to) {
+                waiter
+                    .send(payload.to_vec())
+                    .map_err(|_| MsgBusError::Request("pending request dropped".to_string()))
+            } else {
+                // fall back to publish semantics if no pending request exists
+                let sender = ensure_subject(&self.subjects, reply_to);
+                let message = BusMessage {
+                    subject: reply_to.to_string(),
+                    payload: payload.to_vec(),
+                    reply: None,
+                };
+                sender
+                    .send(message)
+                    .map(|_| ())
+                    .map_err(|_| MsgBusError::UnknownReplySubject(reply_to.to_string()))
+            }
+        }
+    }
+
+    pub use MockBus as Client;
+}
+
+#[cfg(feature = "mock")]
+pub use mock_impl::Client as MockBus;
+
+#[cfg(all(test, feature = "mock"))]
+mod tests {
+    use futures::StreamExt;
+
+    use super::{MessageBus, MockBus};
+
+    #[tokio::test]
+    async fn mock_bus_round_trip() {
+        let bus = MockBus::new();
+        let mut subscription = bus.subscribe("test.subject").await.expect("subscribe");
+
+        let handle = tokio::spawn({
+            let bus = bus.clone();
+            async move {
+                if let Some(message) = subscription.next().await {
+                    assert_eq!(message.subject, "test.subject");
+                    assert_eq!(message.payload, b"ping");
+                    message.respond(&bus, b"pong").await.expect("respond");
+                }
+            }
+        });
+
+        let response = bus.request("test.subject", b"ping").await.expect("request");
+
+        assert_eq!(response.payload, b"pong");
+        handle.await.expect("subscription task");
+    }
 }

--- a/scripts/dev/nats.sh
+++ b/scripts/dev/nats.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNTIME=${CONTAINER_RUNTIME:-docker}
+IMAGE=${NATS_IMAGE:-nats:2.10}
+PORT=${NATS_PORT:-4222}
+HTTP_PORT=${NATS_HTTP_PORT:-8222}
+NAME=${NATS_CONTAINER_NAME:-lokan-nats}
+
+if ! command -v "$RUNTIME" >/dev/null 2>&1; then
+  echo "error: container runtime '$RUNTIME' not found" >&2
+  exit 1
+fi
+
+ARGS=(
+  run
+  --rm
+  --name "$NAME"
+  -p "${PORT}:4222"
+  -p "${HTTP_PORT}:8222"
+  "$IMAGE"
+  -js
+  "--http_port=${HTTP_PORT}"
+)
+
+echo "Starting NATS (${IMAGE}) on ports ${PORT}/tcp and ${HTTP_PORT}/tcp via ${RUNTIME}..."
+exec "$RUNTIME" "${ARGS[@]}"

--- a/services/api-gateway/Cargo.toml
+++ b/services/api-gateway/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 [dependencies]
 axum = { workspace = true }
 common-config = { workspace = true }
+common-mdns = { workspace = true }
+common-msgbus = { workspace = true }
 common-obs = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/services/api-gateway/src/main.rs
+++ b/services/api-gateway/src/main.rs
@@ -1,22 +1,36 @@
 use std::net::SocketAddr;
 
 use axum::Router;
-use common_config::service_port;
+use common_config::{load, MsgBusConfig, ServiceConfig};
+use common_mdns::announce;
+use common_msgbus::{NatsBus, NatsConfig};
 use common_obs::health_router;
+use serde::Deserialize;
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "api-gateway";
-const PORT_ENV: &str = "API_GATEWAY_PORT";
-const DEFAULT_PORT: u16 = 8000;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing();
 
-    let port = service_port(PORT_ENV, DEFAULT_PORT);
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let config = load::<ApiGatewayConfig>()?;
+    let addr = config.socket_addr()?;
     tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+
+    let bus_config = NatsConfig {
+        url: config.bus.url.clone(),
+        request_timeout: config.bus.request_timeout(),
+    };
+    let _bus = NatsBus::connect(bus_config).await?;
+
+    let _mdns = if config.announce_mdns {
+        Some(announce(&config.mdns_service, config.port).await?)
+    } else {
+        tracing::info!(service = SERVICE_NAME, "mDNS announcement disabled");
+        None
+    };
 
     let app = Router::new().merge(health_router(SERVICE_NAME));
 
@@ -29,4 +43,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+struct ApiGatewayConfig {
+    pub bind_address: String,
+    pub port: u16,
+    pub announce_mdns: bool,
+    pub mdns_service: String,
+    #[serde(flatten)]
+    pub bus: MsgBusConfig,
+}
+
+impl Default for ApiGatewayConfig {
+    fn default() -> Self {
+        Self {
+            bind_address: "0.0.0.0".to_string(),
+            port: 8000,
+            announce_mdns: true,
+            mdns_service: "_lokan._tcp".to_string(),
+            bus: MsgBusConfig::default(),
+        }
+    }
+}
+
+impl ServiceConfig for ApiGatewayConfig {
+    const PREFIX: &'static str = "API_GATEWAY_";
+
+    fn apply_environment_overrides(&mut self, prefix: &str) {
+        self.bus.apply_environment_overrides(prefix);
+    }
+}
+
+impl ApiGatewayConfig {
+    fn socket_addr(&self) -> Result<SocketAddr, std::net::AddrParseError> {
+        format!("{}:{}", self.bind_address, self.port).parse()
+    }
 }

--- a/services/radio-coord/Cargo.toml
+++ b/services/radio-coord/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 [dependencies]
 axum = { workspace = true }
 common-config = { workspace = true }
+common-mdns = { workspace = true }
+common-msgbus = { workspace = true }
 common-obs = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/services/radio-coord/src/main.rs
+++ b/services/radio-coord/src/main.rs
@@ -1,22 +1,36 @@
 use std::net::SocketAddr;
 
 use axum::Router;
-use common_config::service_port;
+use common_config::{load, MsgBusConfig, ServiceConfig};
+use common_mdns::announce;
+use common_msgbus::{NatsBus, NatsConfig};
 use common_obs::health_router;
+use serde::Deserialize;
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "radio-coord";
-const PORT_ENV: &str = "RADIO_COORD_PORT";
-const DEFAULT_PORT: u16 = 8009;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing();
 
-    let port = service_port(PORT_ENV, DEFAULT_PORT);
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let config = load::<RadioCoordConfig>()?;
+    let addr = config.socket_addr()?;
     tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+
+    let bus_config = NatsConfig {
+        url: config.bus.url.clone(),
+        request_timeout: config.bus.request_timeout(),
+    };
+    let _bus = NatsBus::connect(bus_config).await?;
+
+    let _mdns = if config.announce_mdns {
+        Some(announce(&config.mdns_service, config.port).await?)
+    } else {
+        tracing::info!(service = SERVICE_NAME, "mDNS announcement disabled");
+        None
+    };
 
     let app = Router::new().merge(health_router(SERVICE_NAME));
 
@@ -29,4 +43,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+struct RadioCoordConfig {
+    pub bind_address: String,
+    pub port: u16,
+    pub announce_mdns: bool,
+    pub mdns_service: String,
+    #[serde(flatten)]
+    pub bus: MsgBusConfig,
+}
+
+impl Default for RadioCoordConfig {
+    fn default() -> Self {
+        Self {
+            bind_address: "0.0.0.0".to_string(),
+            port: 8009,
+            announce_mdns: true,
+            mdns_service: "_lokan._tcp".to_string(),
+            bus: MsgBusConfig::default(),
+        }
+    }
+}
+
+impl ServiceConfig for RadioCoordConfig {
+    const PREFIX: &'static str = "RADIO_COORD_";
+
+    fn apply_environment_overrides(&mut self, prefix: &str) {
+        self.bus.apply_environment_overrides(prefix);
+    }
+}
+
+impl RadioCoordConfig {
+    fn socket_addr(&self) -> Result<SocketAddr, std::net::AddrParseError> {
+        format!("{}:{}", self.bind_address, self.port).parse()
+    }
 }


### PR DESCRIPTION
## Summary
- implement a common message bus abstraction with a NATS backend and in-process mock
- add shared config loader, mDNS announcer stub, and BLE commissioning request/response types
- wire api-gateway and radio-coord to the new config and bus layers and include a dev NATS helper script

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d5b22ea1ac832f9665acef5a37ef97