### PR TITLE
feat(domain): registry, rules, scenes, presence, energy, audit MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +38,27 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "api-gateway"
@@ -96,7 +130,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -110,10 +153,14 @@ name = "audit-log"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64 0.21.7",
+ "chrono",
  "common-config",
  "common-obs",
  "serde",
  "serde_json",
+ "sha2",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -157,6 +204,8 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -175,8 +224,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -202,6 +253,41 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "headers",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -276,7 +362,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -290,6 +376,9 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -305,6 +394,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -341,6 +436,20 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -454,6 +563,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,7 +625,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -533,14 +672,22 @@ dependencies = [
 name = "device-registry"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "axum-extra",
  "common-config",
  "common-obs",
+ "futures-core",
+ "futures-util",
  "serde",
  "serde_json",
+ "sqlx",
+ "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -550,7 +697,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -561,7 +710,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -603,6 +752,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -618,8 +770,12 @@ name = "energy-svc"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "common-config",
  "common-obs",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -651,6 +807,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +840,17 @@ name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -757,6 +941,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +965,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -891,12 +1086,91 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.3.1",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -1053,6 +1327,30 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1229,6 +1527,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -1244,6 +1545,34 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.9.4",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1290,6 +1619,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1664,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.3.1",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1388,10 +1744,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "object"
@@ -1431,7 +1834,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1453,6 +1856,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1877,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1491,6 +1910,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -1542,10 +1972,18 @@ dependencies = [
 name = "presence-svc"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "chrono",
  "common-config",
+ "common-msgbus",
  "common-obs",
+ "futures-core",
+ "futures-util",
+ "serde",
+ "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1557,7 +1995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1726,15 +2164,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rule-engine"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "common-config",
+ "common-msgbus",
  "common-obs",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -1888,9 +2354,14 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "scene-svc"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "common-config",
  "common-obs",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1977,7 +2448,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2021,7 +2492,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2047,6 +2518,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2130,6 +2612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,16 +2631,246 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.9.4",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.9.4",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2182,7 +2903,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2248,7 +2969,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2302,6 +3023,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,7 +3063,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2369,6 +3105,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2432,7 +3181,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2491,16 +3240,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2539,10 +3339,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2596,6 +3420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,7 +3448,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -2653,7 +3483,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2684,10 +3514,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2888,7 +3781,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2909,7 +3802,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2929,7 +3822,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2969,5 +3862,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/services/audit-log/Cargo.toml
+++ b/services/audit-log/Cargo.toml
@@ -4,11 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { workspace = true }
-common-config = { workspace = true }
-common-obs = { workspace = true }
-serde = { workspace = true }
+axum = { workspace = true, features = ["macros", "json"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+common-config = { workspace = true }
+common-obs = { workspace = true }
+sha2 = "0.10"
+base64 = "0.21"
+thiserror = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }

--- a/services/audit-log/src/main.rs
+++ b/services/audit-log/src/main.rs
@@ -1,17 +1,87 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
 
+use axum::extract::State;
 use axum::http::StatusCode;
-use axum::routing::post;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
 use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::fs::{self, OpenOptions};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tracing_subscriber::EnvFilter;
+
 use common_config::service_port;
 use common_obs::health_router;
-use serde::Deserialize;
-use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 const SERVICE_NAME: &str = "audit-log";
 const PORT_ENV: &str = "AUDIT_LOG_PORT";
 const DEFAULT_PORT: u16 = 8008;
+const DEFAULT_PATH: &str = "audit.log";
+
+#[derive(Clone)]
+struct AppState {
+    writer: Arc<Mutex<AuditWriter>>,
+}
+
+struct AuditWriter {
+    path: PathBuf,
+    prev_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IncomingEvent {
+    actor: String,
+    role: String,
+    action: String,
+    resource: String,
+    outcome: String,
+    #[serde(default)]
+    detail: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AuditRecord {
+    timestamp: DateTime<Utc>,
+    prev_hash: String,
+    hash: String,
+    event: IncomingEvent,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum AuditError {
+    #[error("i/o error: {0}")]
+    Io(String),
+    #[error("malformed log entry")]
+    Malformed,
+}
+
+impl From<std::io::Error> for AuditError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value.to_string())
+    }
+}
+
+impl IntoResponse for AuditError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match self {
+            AuditError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            AuditError::Malformed => StatusCode::BAD_REQUEST,
+        };
+        (
+            status,
+            Json(serde_json::json!({ "error": self.to_string() })),
+        )
+            .into_response()
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,10 +89,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+    let log_path = std::env::var("AUDIT_LOG_PATH").unwrap_or_else(|_| DEFAULT_PATH.to_string());
+
+    let writer = AuditWriter::new(PathBuf::from(&log_path)).await?;
+    let state = AppState {
+        writer: Arc::new(Mutex::new(writer)),
+    };
+
+    tracing::info!(%addr, %log_path, service = SERVICE_NAME, "starting service");
 
     let app = Router::new()
         .route("/v1/events", post(record_event))
+        .route("/v1/events/export", get(export_events))
+        .with_state(state)
         .merge(health_router(SERVICE_NAME));
 
     let listener = TcpListener::bind(addr).await?;
@@ -36,26 +115,99 @@ fn init_tracing() {
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
 
-#[derive(Debug, Deserialize)]
-struct IncomingEvent {
-    actor: String,
-    role: String,
-    action: String,
-    resource: String,
-    outcome: String,
-    #[serde(default)]
-    detail: Option<serde_json::Value>,
+async fn record_event(
+    State(state): State<AppState>,
+    Json(event): Json<IncomingEvent>,
+) -> Result<StatusCode, AuditError> {
+    let mut writer = state.writer.lock().await;
+    writer.append(event).await?;
+    Ok(StatusCode::ACCEPTED)
 }
 
-async fn record_event(Json(event): Json<IncomingEvent>) -> StatusCode {
-    tracing::info!(
-        actor = %event.actor,
-        role = %event.role,
-        action = %event.action,
-        resource = %event.resource,
-        outcome = %event.outcome,
-        detail = ?event.detail,
-        "received audit event"
-    );
-    StatusCode::ACCEPTED
+async fn export_events(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<AuditRecord>>, AuditError> {
+    let writer = state.writer.lock().await;
+    let entries = writer.read_all().await?;
+    Ok(Json(entries))
+}
+
+impl AuditWriter {
+    async fn new(path: PathBuf) -> Result<Self, AuditError> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).await?;
+            }
+        }
+
+        let prev_hash = Self::hydrate_prev_hash(&path).await?;
+        Ok(Self { path, prev_hash })
+    }
+
+    async fn hydrate_prev_hash(path: &PathBuf) -> Result<Vec<u8>, AuditError> {
+        if !path.exists() {
+            return Ok(vec![0u8; 32]);
+        }
+        let contents = fs::read(path).await?;
+        if contents.is_empty() {
+            return Ok(vec![0u8; 32]);
+        }
+        let mut prev = vec![0u8; 32];
+        for line in contents
+            .split(|b| *b == b'\n')
+            .filter(|line| !line.is_empty())
+        {
+            let record: AuditRecord =
+                serde_json::from_slice(line).map_err(|_| AuditError::Malformed)?;
+            prev = STANDARD
+                .decode(record.hash)
+                .map_err(|_| AuditError::Malformed)?;
+        }
+        Ok(prev)
+    }
+
+    async fn append(&mut self, event: IncomingEvent) -> Result<(), AuditError> {
+        let timestamp = Utc::now();
+        let mut hasher = Sha256::new();
+        hasher.update(&self.prev_hash);
+        hasher.update(serde_json::to_vec(&event).map_err(|_| AuditError::Malformed)?);
+        let hash = hasher.finalize();
+        let record = AuditRecord {
+            timestamp,
+            prev_hash: STANDARD.encode(&self.prev_hash),
+            hash: STANDARD.encode(&hash),
+            event,
+        };
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await?;
+        file.write_all(
+            serde_json::to_vec(&record)
+                .map_err(|_| AuditError::Malformed)?
+                .as_slice(),
+        )
+        .await?;
+        file.write_all(b"\n").await?;
+        self.prev_hash = hash.to_vec();
+        Ok(())
+    }
+
+    async fn read_all(&self) -> Result<Vec<AuditRecord>, AuditError> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let contents = fs::read(&self.path).await?;
+        let mut records = Vec::new();
+        for line in contents
+            .split(|b| *b == b'\n')
+            .filter(|line| !line.is_empty())
+        {
+            let record: AuditRecord =
+                serde_json::from_slice(line).map_err(|_| AuditError::Malformed)?;
+            records.push(record);
+        }
+        Ok(records)
+    }
 }

--- a/services/device-registry/Cargo.toml
+++ b/services/device-registry/Cargo.toml
@@ -3,12 +3,25 @@ name = "device-registry"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["sqlite"]
+sqlite = ["sqlx/sqlite"]
+postgres = ["sqlx/postgres"]
+
 [dependencies]
-axum = { workspace = true }
-common-config = { workspace = true }
-common-obs = { workspace = true }
-serde = { workspace = true }
+axum = { workspace = true, features = ["ws", "macros", "json"] }
+axum-extra = { version = "0.9", features = ["typed-header"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { version = "1", features = ["serde", "v4"] }
+common-config = { workspace = true }
+common-obs = { workspace = true }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "macros", "chrono", "migrate", "json", "any"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures-util = { version = "0.3", features = ["sink"] }
+futures-core = "0.3"
+anyhow = "1"
+thiserror = "1"

--- a/services/device-registry/src/main.rs
+++ b/services/device-registry/src/main.rs
@@ -1,16 +1,132 @@
-use std::net::SocketAddr;
-
-use axum::routing::get;
+use axum::extract::{ws::Message, Path, State, WebSocketUpgrade};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive};
+use axum::response::{IntoResponse, Sse};
+use axum::routing::{get, put};
 use axum::{Json, Router};
+use futures_core::Stream;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tracing_subscriber::EnvFilter;
+use uuid::Uuid;
+
+use sqlx::Row;
+
 use common_config::service_port;
 use common_obs::health_router;
-use serde::Serialize;
-use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
+
+#[cfg(all(feature = "sqlite", feature = "postgres"))]
+compile_error!("enable only one backend feature at a time");
+
+type DbPool = sqlx::AnyPool;
 
 const SERVICE_NAME: &str = "device-registry";
 const PORT_ENV: &str = "DEVICE_REGISTRY_PORT";
 const DEFAULT_PORT: u16 = 8001;
+#[cfg(feature = "postgres")]
+const DEFAULT_DB_URL: &str = "postgres://localhost/device_registry";
+#[cfg(not(feature = "postgres"))]
+const DEFAULT_DB_URL: &str = "sqlite://device-registry.db";
+
+#[derive(Clone)]
+struct AppState {
+    pool: DbPool,
+    events: broadcast::Sender<DeviceEvent>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DeviceEvent {
+    kind: EventKind,
+    device_id: String,
+    payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EventKind {
+    Created,
+    Updated,
+    Deleted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Room {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Device {
+    id: String,
+    room_id: Option<String>,
+    name: String,
+    kind: String,
+    status: String,
+    state: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Capability {
+    id: i64,
+    device_id: String,
+    capability: String,
+    properties: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct NewRoom {
+    name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct NewDevice {
+    room_id: Option<String>,
+    name: String,
+    kind: String,
+    #[serde(default = "default_status")]
+    status: String,
+    #[serde(default)]
+    state: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UpdateDevice {
+    room_id: Option<String>,
+    name: Option<String>,
+    kind: Option<String>,
+    status: Option<String>,
+    state: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CapabilityPayload {
+    capability: String,
+    #[serde(default)]
+    properties: serde_json::Value,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RegistryError {
+    #[error("record not found")]
+    NotFound,
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+impl IntoResponse for RegistryError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match self {
+            RegistryError::NotFound => StatusCode::NOT_FOUND,
+            RegistryError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let msg = self.to_string();
+        (status, Json(serde_json::json!({ "error": msg }))).into_response()
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,10 +134,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+
+    let database_url = std::env::var("DEVICE_REGISTRY_DATABASE_URL")
+        .unwrap_or_else(|_| DEFAULT_DB_URL.to_string());
+
+    let pool = init_pool(&database_url).await?;
+    init_schema(&pool).await?;
+
+    let (tx, _) = broadcast::channel(64);
+    let state = AppState { pool, events: tx };
+
+    tracing::info!(%addr, db = %database_url, service = SERVICE_NAME, "starting service");
 
     let app = Router::new()
-        .route("/v1/devices", get(list_devices))
+        .route("/v1/rooms", get(list_rooms).post(create_room))
+        .route("/v1/devices", get(list_devices).post(create_device))
+        .route(
+            "/v1/devices/:id",
+            get(fetch_device).put(update_device).delete(delete_device),
+        )
+        .route("/v1/devices/:id/state", put(update_device_state))
+        .route(
+            "/v1/devices/:id/capabilities",
+            get(list_capabilities).post(add_capability),
+        )
+        .route("/v1/events/sse", get(events_sse))
+        .route("/v1/events/ws", get(events_ws))
+        .with_state(state)
         .merge(health_router(SERVICE_NAME));
 
     let listener = TcpListener::bind(addr).await?;
@@ -35,31 +174,349 @@ fn init_tracing() {
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
 
-#[derive(Debug, Serialize)]
-struct DeviceRecord {
-    id: String,
-    name: String,
-    status: String,
+async fn init_pool(url: &str) -> Result<DbPool, sqlx::Error> {
+    sqlx::AnyPool::connect(url).await
 }
 
-#[derive(Debug, Serialize)]
-struct DevicesResponse {
-    devices: Vec<DeviceRecord>,
+async fn init_schema(pool: &DbPool) -> Result<(), sqlx::Error> {
+    #[cfg(feature = "postgres")]
+    let create_capabilities = "CREATE TABLE IF NOT EXISTS capabilities (
+        id SERIAL PRIMARY KEY,
+        device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+        capability TEXT NOT NULL,
+        properties TEXT NOT NULL
+    )";
+
+    #[cfg(not(feature = "postgres"))]
+    let create_capabilities = "CREATE TABLE IF NOT EXISTS capabilities (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+        capability TEXT NOT NULL,
+        properties TEXT NOT NULL
+    )";
+
+    let create_rooms = "CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY, name TEXT NOT NULL)";
+    let create_devices = "CREATE TABLE IF NOT EXISTS devices (
+        id TEXT PRIMARY KEY,
+        room_id TEXT REFERENCES rooms(id) ON DELETE SET NULL,
+        name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        status TEXT NOT NULL,
+        state TEXT NOT NULL
+    )";
+    sqlx::query(create_rooms).execute(pool).await?;
+    sqlx::query(create_devices).execute(pool).await?;
+    sqlx::query(create_capabilities).execute(pool).await?;
+    Ok(())
 }
 
-async fn list_devices() -> Json<DevicesResponse> {
-    Json(DevicesResponse {
-        devices: vec![
-            DeviceRecord {
-                id: "device-1".to_string(),
-                name: "Test Thermostat".to_string(),
-                status: "online".to_string(),
+async fn list_rooms(State(state): State<AppState>) -> Result<Json<Vec<Room>>, RegistryError> {
+    let rows = sqlx::query("SELECT id, name FROM rooms ORDER BY name")
+        .fetch_all(&state.pool)
+        .await?;
+
+    let rooms = rows
+        .into_iter()
+        .map(|row| Room {
+            id: row.get("id"),
+            name: row.get("name"),
+        })
+        .collect();
+    Ok(Json(rooms))
+}
+
+async fn create_room(
+    State(state): State<AppState>,
+    Json(payload): Json<NewRoom>,
+) -> Result<Json<Room>, RegistryError> {
+    let id = Uuid::new_v4().to_string();
+    let name = payload.name;
+    sqlx::query("INSERT INTO rooms (id, name) VALUES (?, ?)")
+        .bind(&id)
+        .bind(&name)
+        .execute(&state.pool)
+        .await?;
+    let room = Room { id, name };
+    Ok(Json(room))
+}
+
+async fn list_devices(State(state): State<AppState>) -> Result<Json<Vec<Device>>, RegistryError> {
+    let rows =
+        sqlx::query("SELECT id, room_id, name, kind, status, state FROM devices ORDER BY name")
+            .fetch_all(&state.pool)
+            .await?;
+    let devices = rows
+        .into_iter()
+        .map(|row| Device {
+            id: row.get("id"),
+            room_id: row.get("room_id"),
+            name: row.get("name"),
+            kind: row.get("kind"),
+            status: row.get("status"),
+            state: parse_state(row.get("state")),
+        })
+        .collect();
+    Ok(Json(devices))
+}
+
+async fn create_device(
+    State(state): State<AppState>,
+    Json(payload): Json<NewDevice>,
+) -> Result<Json<Device>, RegistryError> {
+    let id = Uuid::new_v4().to_string();
+    let room_id = payload.room_id.clone();
+    let name = payload.name.clone();
+    let kind = payload.kind.clone();
+    let status = payload.status.clone();
+    let state_value = payload.state.clone();
+    let state_json = serde_json::to_string(&payload.state).unwrap_or_else(|_| "{}".to_string());
+    sqlx::query(
+        "INSERT INTO devices (id, room_id, name, kind, status, state) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(&room_id)
+    .bind(&name)
+    .bind(&kind)
+    .bind(&status)
+    .bind(state_json)
+    .execute(&state.pool)
+    .await?;
+
+    let device = Device {
+        id: id.clone(),
+        room_id,
+        name,
+        kind,
+        status,
+        state: state_value,
+    };
+
+    publish_event(&state.events, EventKind::Created, &id, &device);
+    Ok(Json(device))
+}
+
+async fn fetch_device(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Device>, RegistryError> {
+    let record =
+        sqlx::query("SELECT id, room_id, name, kind, status, state FROM devices WHERE id = ?")
+            .bind(&id)
+            .fetch_optional(&state.pool)
+            .await?;
+
+    let record = record.ok_or(RegistryError::NotFound)?;
+    let device = Device {
+        id: record.get("id"),
+        room_id: record.get("room_id"),
+        name: record.get("name"),
+        kind: record.get("kind"),
+        status: record.get("status"),
+        state: parse_state(record.get("state")),
+    };
+    Ok(Json(device))
+}
+
+async fn update_device(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(payload): Json<UpdateDevice>,
+) -> Result<Json<Device>, RegistryError> {
+    let existing = fetch_device(State(state.clone()), Path(id.clone()))
+        .await?
+        .0;
+    let updated_name = payload.name.unwrap_or(existing.name.clone());
+    let updated_kind = payload.kind.unwrap_or(existing.kind.clone());
+    let updated_status = payload.status.unwrap_or(existing.status.clone());
+    let updated_state = payload.state.unwrap_or(existing.state.clone());
+
+    sqlx::query(
+        "UPDATE devices SET room_id = ?, name = ?, kind = ?, status = ?, state = ? WHERE id = ?",
+    )
+    .bind(payload.room_id.clone().or(existing.room_id.clone()))
+    .bind(&updated_name)
+    .bind(&updated_kind)
+    .bind(&updated_status)
+    .bind(serde_json::to_string(&updated_state).unwrap_or_else(|_| existing.state.to_string()))
+    .bind(&id)
+    .execute(&state.pool)
+    .await?;
+
+    let device = Device {
+        id: id.clone(),
+        room_id: payload.room_id.or(existing.room_id),
+        name: updated_name,
+        kind: updated_kind,
+        status: updated_status,
+        state: updated_state,
+    };
+
+    publish_event(&state.events, EventKind::Updated, &id, &device);
+    Ok(Json(device))
+}
+
+async fn update_device_state(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(new_state): Json<serde_json::Value>,
+) -> Result<Json<Device>, RegistryError> {
+    let existing = fetch_device(State(state.clone()), Path(id.clone()))
+        .await?
+        .0;
+    sqlx::query("UPDATE devices SET state = ? WHERE id = ?")
+        .bind(serde_json::to_string(&new_state).unwrap_or_else(|_| existing.state.to_string()))
+        .bind(&id)
+        .execute(&state.pool)
+        .await?;
+
+    let device = Device {
+        state: new_state.clone(),
+        ..existing
+    };
+    publish_event(&state.events, EventKind::Updated, &device.id, &device);
+    Ok(Json(device))
+}
+
+async fn delete_device(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, RegistryError> {
+    let result = sqlx::query("DELETE FROM devices WHERE id = ?")
+        .bind(&id)
+        .execute(&state.pool)
+        .await?;
+    if result.rows_affected() == 0 {
+        return Err(RegistryError::NotFound);
+    }
+    publish_event(
+        &state.events,
+        EventKind::Deleted,
+        &id,
+        &serde_json::json!({}),
+    );
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_capabilities(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<Capability>>, RegistryError> {
+    let records = sqlx::query(
+        "SELECT id, device_id, capability, properties FROM capabilities WHERE device_id = ?",
+    )
+    .bind(&id)
+    .fetch_all(&state.pool)
+    .await?;
+
+    let caps = records
+        .into_iter()
+        .map(|row| Capability {
+            id: row.get("id"),
+            device_id: row.get("device_id"),
+            capability: row.get("capability"),
+            properties: parse_state(row.get("properties")),
+        })
+        .collect();
+    Ok(Json(caps))
+}
+
+async fn add_capability(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(payload): Json<CapabilityPayload>,
+) -> Result<Json<Capability>, RegistryError> {
+    let properties =
+        serde_json::to_string(&payload.properties).unwrap_or_else(|_| "{}".to_string());
+    sqlx::query("INSERT INTO capabilities (device_id, capability, properties) VALUES (?, ?, ?)")
+        .bind(&id)
+        .bind(&payload.capability)
+        .bind(&properties)
+        .execute(&state.pool)
+        .await?;
+    let record = sqlx::query(
+        "SELECT id FROM capabilities WHERE device_id = ? AND capability = ? ORDER BY id DESC LIMIT 1",
+    )
+    .bind(&id)
+    .bind(&payload.capability)
+    .fetch_one(&state.pool)
+    .await?;
+    let cap_id: i64 = record.get("id");
+    let capability = Capability {
+        id: cap_id,
+        device_id: id.clone(),
+        capability: payload.capability,
+        properties: payload.properties,
+    };
+    publish_event(
+        &state.events,
+        EventKind::Updated,
+        &id,
+        &serde_json::json!({ "capability": capability.capability }),
+    );
+    Ok(Json(capability))
+}
+
+async fn events_sse(
+    State(state): State<AppState>,
+) -> Sse<impl Stream<Item = Result<Event, anyhow::Error>>> {
+    let stream = BroadcastStream::new(state.events.subscribe()).filter_map(|event| async {
+        match event {
+            Ok(ev) => match serde_json::to_string(&ev) {
+                Ok(payload) => Some(Ok(Event::default().data(payload))),
+                Err(err) => Some(Err(anyhow::anyhow!(err))),
             },
-            DeviceRecord {
-                id: "device-2".to_string(),
-                name: "Garage Door".to_string(),
-                status: "offline".to_string(),
-            },
-        ],
+            Err(_) => None,
+        }
+    });
+
+    Sse::new(stream).keep_alive(KeepAlive::new())
+}
+
+async fn events_ws(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| async move {
+        let mut receiver = BroadcastStream::new(state.events.subscribe()).fuse();
+        let (mut tx, mut rx) = socket.split();
+        tokio::spawn(async move {
+            while let Some(event) = receiver.next().await {
+                if let Ok(event) = event {
+                    if let Ok(payload) = serde_json::to_string(&event) {
+                        if tx.send(Message::Text(payload)).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        // drain incoming messages to keep connection alive
+        while let Some(Ok(msg)) = rx.next().await {
+            if matches!(msg, Message::Close(_)) {
+                break;
+            }
+        }
     })
+}
+
+fn publish_event<T: Serialize>(
+    sender: &broadcast::Sender<DeviceEvent>,
+    kind: EventKind,
+    device_id: &str,
+    payload: T,
+) {
+    if let Ok(payload) = serde_json::to_value(payload) {
+        let event = DeviceEvent {
+            kind,
+            device_id: device_id.to_string(),
+            payload,
+        };
+        let _ = sender.send(event);
+    }
+}
+
+fn default_status() -> String {
+    "unknown".to_string()
+}
+
+fn parse_state(raw: String) -> serde_json::Value {
+    serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({}))
 }

--- a/services/energy-svc/Cargo.toml
+++ b/services/energy-svc/Cargo.toml
@@ -4,9 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { workspace = true }
-common-config = { workspace = true }
-common-obs = { workspace = true }
-tokio = { workspace = true }
+axum = { workspace = true, features = ["macros", "json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+common-config = { workspace = true }
+common-obs = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = { workspace = true }

--- a/services/energy-svc/src/main.rs
+++ b/services/energy-svc/src/main.rs
@@ -1,14 +1,77 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
-use axum::Router;
+use axum::extract::{Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Local, NaiveTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+use tracing_subscriber::EnvFilter;
+
 use common_config::service_port;
 use common_obs::health_router;
-use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "energy-svc";
 const PORT_ENV: &str = "ENERGY_SVC_PORT";
 const DEFAULT_PORT: u16 = 8005;
+
+#[derive(Clone)]
+struct AppState {
+    state: Arc<RwLock<EnergyState>>,
+}
+
+#[derive(Clone, Default)]
+struct EnergyState {
+    budgets: HashMap<String, EnergyBudget>,
+    tou_windows: Vec<TimeOfUseWindow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EnergyBudget {
+    id: String,
+    limit_kwh: f32,
+    #[serde(default)]
+    period: BudgetPeriod,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BudgetPeriod {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+impl Default for BudgetPeriod {
+    fn default() -> Self {
+        Self::Daily
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TimeOfUseWindow {
+    name: String,
+    start: String,
+    end: String,
+    #[serde(default = "default_multiplier")]
+    rate_multiplier: f32,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdviceQuery {
+    #[serde(default)]
+    consumption_kwh: f32,
+}
+
+#[derive(Debug, Serialize)]
+struct AdviceResponse {
+    timestamp: DateTime<Utc>,
+    summary: String,
+    recommendations: Vec<String>,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,9 +79,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
+
+    let state = AppState {
+        state: Arc::new(RwLock::new(EnergyState::default())),
+    };
+
     tracing::info!(%addr, service = SERVICE_NAME, "starting service");
 
-    let app = Router::new().merge(health_router(SERVICE_NAME));
+    let app = Router::new()
+        .route("/v1/budgets", post(set_budgets))
+        .route("/v1/tou", post(set_tou_windows))
+        .route("/v1/advice", get(get_advice))
+        .with_state(state)
+        .merge(health_router(SERVICE_NAME));
 
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service()).await?;
@@ -29,4 +102,101 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+async fn set_budgets(
+    State(state): State<AppState>,
+    Json(budgets): Json<Vec<EnergyBudget>>,
+) -> Json<StatusReply> {
+    let mut guard = state.state.write().await;
+    guard.budgets = budgets
+        .into_iter()
+        .map(|budget| (budget.id.clone(), budget))
+        .collect();
+    StatusReply::ok("budgets updated")
+}
+
+async fn set_tou_windows(
+    State(state): State<AppState>,
+    Json(windows): Json<Vec<TimeOfUseWindow>>,
+) -> Json<StatusReply> {
+    let mut guard = state.state.write().await;
+    guard.tou_windows = windows;
+    StatusReply::ok("time-of-use windows updated")
+}
+
+async fn get_advice(
+    State(state): State<AppState>,
+    Query(query): Query<AdviceQuery>,
+) -> Json<AdviceResponse> {
+    let snapshot = state.state.read().await.clone();
+    let now_local: DateTime<Local> = Local::now();
+    let current_time = now_local.time();
+
+    let mut recommendations = Vec::new();
+    for window in &snapshot.tou_windows {
+        if let Some((start, end)) = parse_window(window) {
+            if in_window(current_time, start, end) && window.rate_multiplier > 1.0 {
+                recommendations.push(format!(
+                    "High rate period ({}) active. Consider delaying discretionary loads.",
+                    window.name
+                ));
+            }
+        }
+    }
+
+    for budget in snapshot.budgets.values() {
+        if query.consumption_kwh > budget.limit_kwh {
+            recommendations.push(format!(
+                "{} budget exceeded by {:.2} kWh. Reduce usage or reschedule appliances.",
+                match budget.period {
+                    BudgetPeriod::Daily => "Daily",
+                    BudgetPeriod::Weekly => "Weekly",
+                    BudgetPeriod::Monthly => "Monthly",
+                },
+                query.consumption_kwh - budget.limit_kwh
+            ));
+        }
+    }
+
+    if recommendations.is_empty() {
+        recommendations.push("Usage within configured thresholds.".to_string());
+    }
+
+    Json(AdviceResponse {
+        timestamp: Utc::now(),
+        summary: format!("Current consumption {:.2} kWh", query.consumption_kwh),
+        recommendations,
+    })
+}
+
+fn parse_window(window: &TimeOfUseWindow) -> Option<(NaiveTime, NaiveTime)> {
+    let start = NaiveTime::parse_from_str(&window.start, "%H:%M").ok()?;
+    let end = NaiveTime::parse_from_str(&window.end, "%H:%M").ok()?;
+    Some((start, end))
+}
+
+fn in_window(now: NaiveTime, start: NaiveTime, end: NaiveTime) -> bool {
+    if start <= end {
+        now >= start && now <= end
+    } else {
+        now >= start || now <= end
+    }
+}
+
+fn default_multiplier() -> f32 {
+    1.0
+}
+
+#[derive(Debug, Serialize)]
+struct StatusReply {
+    message: String,
+}
+
+impl StatusReply {
+    fn ok(message: &str) -> Json<Self> {
+        Json(Self {
+            message: message.to_string(),
+        })
+    }
 }

--- a/services/presence-svc/Cargo.toml
+++ b/services/presence-svc/Cargo.toml
@@ -4,9 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { workspace = true }
-common-config = { workspace = true }
-common-obs = { workspace = true }
-tokio = { workspace = true }
+axum = { workspace = true, features = ["macros", "json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+common-config = { workspace = true }
+common-obs = { workspace = true }
+common-msgbus = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+futures-util = "0.3"
+futures-core = "0.3"
+tokio-stream = { version = "0.1", features = ["sync"] }
+anyhow = "1"

--- a/services/presence-svc/src/main.rs
+++ b/services/presence-svc/src/main.rs
@@ -1,14 +1,69 @@
 use std::net::SocketAddr;
 
-use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use futures_core::Stream;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tracing_subscriber::EnvFilter;
+
 use common_config::service_port;
 use common_obs::health_router;
-use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "presence-svc";
 const PORT_ENV: &str = "PRESENCE_SVC_PORT";
 const DEFAULT_PORT: u16 = 8004;
+
+#[derive(Clone)]
+struct AppState {
+    events: broadcast::Sender<PresenceEvent>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct WebhookPayload {
+    person_id: String,
+    location: String,
+    #[serde(default = "default_confidence")]
+    confidence: f32,
+    #[serde(default = "now_ts")]
+    observed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BlePayload {
+    beacon_id: String,
+    rssi: i32,
+    room_hint: Option<String>,
+    #[serde(default = "now_ts")]
+    observed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PresenceEvent {
+    source: PresenceSource,
+    person_id: String,
+    location: String,
+    confidence: f32,
+    observed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PresenceSource {
+    Webhook,
+    Ble,
+}
+
+fn default_confidence() -> f32 {
+    0.5
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,9 +71,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
+
+    let (tx, _) = broadcast::channel(128);
+    let state = AppState { events: tx };
+
     tracing::info!(%addr, service = SERVICE_NAME, "starting service");
 
-    let app = Router::new().merge(health_router(SERVICE_NAME));
+    let app = Router::new()
+        .route("/v1/presence/webhook", post(intake_webhook))
+        .route("/v1/presence/ble", post(intake_ble))
+        .route("/v1/presence/events", get(stream_events))
+        .with_state(state)
+        .merge(health_router(SERVICE_NAME));
 
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service()).await?;
@@ -29,4 +93,58 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+async fn intake_webhook(
+    State(state): State<AppState>,
+    Json(payload): Json<WebhookPayload>,
+) -> StatusCode {
+    let event = PresenceEvent {
+        source: PresenceSource::Webhook,
+        person_id: payload.person_id,
+        location: payload.location,
+        confidence: payload.confidence,
+        observed_at: payload.observed_at,
+    };
+    dispatch_event(&state.events, event);
+    StatusCode::ACCEPTED
+}
+
+async fn intake_ble(State(state): State<AppState>, Json(payload): Json<BlePayload>) -> StatusCode {
+    let confidence = 1.0_f32.min(0.2 + ((-payload.rssi) as f32).abs() / 100.0);
+    let event = PresenceEvent {
+        source: PresenceSource::Ble,
+        person_id: payload.beacon_id.clone(),
+        location: payload
+            .room_hint
+            .unwrap_or_else(|| format!("beacon:{}", payload.beacon_id)),
+        confidence,
+        observed_at: payload.observed_at,
+    };
+    dispatch_event(&state.events, event);
+    StatusCode::ACCEPTED
+}
+
+async fn stream_events(
+    State(state): State<AppState>,
+) -> axum::response::Sse<impl Stream<Item = Result<Event, anyhow::Error>>> {
+    let stream = BroadcastStream::new(state.events.subscribe()).filter_map(|event| async {
+        match event {
+            Ok(event) => match serde_json::to_string(&event) {
+                Ok(payload) => Some(Ok(Event::default().data(payload))),
+                Err(err) => Some(Err(anyhow::anyhow!(err))),
+            },
+            Err(_) => None,
+        }
+    });
+    axum::response::Sse::new(stream).keep_alive(KeepAlive::new())
+}
+
+fn dispatch_event(sender: &broadcast::Sender<PresenceEvent>, event: PresenceEvent) {
+    tracing::info!(person = %event.person_id, location = %event.location, source = ?event.source, "presence event");
+    let _ = sender.send(event);
+}
+
+fn now_ts() -> DateTime<Utc> {
+    Utc::now()
 }

--- a/services/rule-engine/Cargo.toml
+++ b/services/rule-engine/Cargo.toml
@@ -4,9 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { workspace = true }
+axum = { workspace = true, features = ["macros", "json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 common-config = { workspace = true }
+common-msgbus = { workspace = true }
 common-obs = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+futures = "0.3"
+parking_lot = "0.12"

--- a/services/rule-engine/src/main.rs
+++ b/services/rule-engine/src/main.rs
@@ -1,14 +1,134 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
 
-use axum::Router;
-use common_config::service_port;
-use common_obs::health_router;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
+use uuid::Uuid;
+
+use common_config::service_port;
+use common_obs::health_router;
 
 const SERVICE_NAME: &str = "rule-engine";
 const PORT_ENV: &str = "RULE_ENGINE_PORT";
 const DEFAULT_PORT: u16 = 8002;
+const TICK_INTERVAL_MS: u64 = 500;
+
+#[derive(Clone)]
+struct AppState {
+    rules: Arc<RwLock<HashMap<String, RuleInstance>>>,
+}
+
+struct RuleInstance {
+    definition: RuleDefinition,
+    schedule: ScheduleState,
+}
+
+#[derive(Clone)]
+struct ScheduleState {
+    next_tick: u64,
+    interval_ticks: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuleDefinition {
+    pub id: String,
+    pub name: Option<String>,
+    pub trigger: Trigger,
+    #[serde(default)]
+    pub conditions: Vec<Condition>,
+    #[serde(default)]
+    pub actions: Vec<Action>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Trigger {
+    Interval { seconds: u64 },
+    Event { subject: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Condition {
+    Equals { left: ValueRef, right: ValueRef },
+    GreaterThan { left: ValueRef, right: ValueRef },
+    LessThan { left: ValueRef, right: ValueRef },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ValueRef {
+    Literal { value: serde_json::Value },
+    Context { path: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Action {
+    EmitEvent {
+        subject: String,
+        payload: serde_json::Value,
+    },
+    SetDeviceState {
+        device_id: String,
+        state: serde_json::Value,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RuleTestRequest {
+    rule: RuleDefinition,
+    #[serde(default)]
+    context: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuleTestResponse {
+    fired: bool,
+    trace: Vec<String>,
+    actions: Vec<ActionExecution>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ActionExecution {
+    action: Action,
+    status: ActionStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ActionStatus {
+    Executed,
+    Skipped,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RuleEngineError {
+    #[error("rule not found")]
+    NotFound,
+}
+
+impl axum::response::IntoResponse for RuleEngineError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match self {
+            RuleEngineError::NotFound => StatusCode::NOT_FOUND,
+        };
+        (
+            status,
+            Json(serde_json::json!({ "error": self.to_string() })),
+        )
+            .into_response()
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,9 +136,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
+
+    let state = AppState {
+        rules: Arc::new(RwLock::new(HashMap::new())),
+    };
+    let scheduler_state = state.clone();
+    tokio::spawn(async move {
+        run_scheduler(scheduler_state).await;
+    });
+
     tracing::info!(%addr, service = SERVICE_NAME, "starting service");
 
-    let app = Router::new().merge(health_router(SERVICE_NAME));
+    let app = Router::new()
+        .route("/v1/rules", get(list_rules).post(create_rule))
+        .route("/v1/rules/:id", delete(delete_rule))
+        .route("/v1/rules:test", post(test_rule))
+        .with_state(state)
+        .merge(health_router(SERVICE_NAME));
 
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service()).await?;
@@ -29,4 +163,314 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+async fn list_rules(State(state): State<AppState>) -> Json<Vec<RuleDefinition>> {
+    let rules = state
+        .rules
+        .read()
+        .values()
+        .map(|instance| instance.definition.clone())
+        .collect();
+    Json(rules)
+}
+
+async fn create_rule(
+    State(state): State<AppState>,
+    Json(mut payload): Json<RuleDefinition>,
+) -> Json<RuleDefinition> {
+    if payload.id.is_empty() {
+        payload.id = Uuid::new_v4().to_string();
+    }
+    let mut guard = state.rules.write();
+    let ticks = guard
+        .values()
+        .map(|instance| instance.schedule.next_tick)
+        .max()
+        .unwrap_or(0);
+    guard.insert(
+        payload.id.clone(),
+        RuleInstance {
+            schedule: ScheduleState::new(&payload.trigger, ticks),
+            definition: payload.clone(),
+        },
+    );
+    Json(payload)
+}
+
+async fn delete_rule(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, RuleEngineError> {
+    let mut guard = state.rules.write();
+    if guard.remove(&id).is_some() {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(RuleEngineError::NotFound)
+    }
+}
+
+async fn test_rule(Json(request): Json<RuleTestRequest>) -> Json<RuleTestResponse> {
+    let now = Utc::now();
+    let evaluation = evaluate_rule(&request.rule, &request.context, now);
+    Json(RuleTestResponse {
+        fired: evaluation.fired,
+        trace: evaluation.trace,
+        actions: evaluation.actions,
+    })
+}
+
+struct EvaluationResult {
+    fired: bool,
+    trace: Vec<String>,
+    actions: Vec<ActionExecution>,
+}
+
+fn evaluate_rule(
+    rule: &RuleDefinition,
+    context: &serde_json::Map<String, serde_json::Value>,
+    now: DateTime<Utc>,
+) -> EvaluationResult {
+    let mut trace = Vec::new();
+    trace.push(format!("evaluating rule {}", rule.id));
+    let mut conditions_met = true;
+
+    for condition in &rule.conditions {
+        match condition.evaluate(context, now) {
+            ConditionState::Matched(msg) => trace.push(msg),
+            ConditionState::Failed(msg) => {
+                trace.push(msg);
+                conditions_met = false;
+                break;
+            }
+        }
+    }
+
+    let mut actions = Vec::new();
+    if conditions_met {
+        for action in &rule.actions {
+            actions.push(ActionExecution {
+                action: action.clone(),
+                status: ActionStatus::Executed,
+            });
+        }
+        trace.push("conditions satisfied".to_string());
+    } else {
+        for action in &rule.actions {
+            actions.push(ActionExecution {
+                action: action.clone(),
+                status: ActionStatus::Skipped,
+            });
+        }
+        trace.push("conditions failed".to_string());
+    }
+
+    EvaluationResult {
+        fired: conditions_met,
+        trace,
+        actions,
+    }
+}
+
+impl Condition {
+    fn evaluate(
+        &self,
+        context: &serde_json::Map<String, serde_json::Value>,
+        now: DateTime<Utc>,
+    ) -> ConditionState {
+        match self {
+            Condition::Equals { left, right } => {
+                let left_value = left.resolve(context, now);
+                let right_value = right.resolve(context, now);
+                if left_value == right_value {
+                    ConditionState::Matched(format!(
+                        "equals matched: {left_value:?} == {right_value:?}"
+                    ))
+                } else {
+                    ConditionState::Failed(format!(
+                        "equals failed: {left_value:?} != {right_value:?}"
+                    ))
+                }
+            }
+            Condition::GreaterThan { left, right } => {
+                compare_numeric("greater_than", left, right, context, now, |l, r| l > r)
+            }
+            Condition::LessThan { left, right } => {
+                compare_numeric("less_than", left, right, context, now, |l, r| l < r)
+            }
+        }
+    }
+}
+
+fn compare_numeric<F: Fn(f64, f64) -> bool>(
+    label: &str,
+    left: &ValueRef,
+    right: &ValueRef,
+    context: &serde_json::Map<String, serde_json::Value>,
+    now: DateTime<Utc>,
+    cmp: F,
+) -> ConditionState {
+    let left_value = left.resolve(context, now);
+    let right_value = right.resolve(context, now);
+    match (left_value.as_f64(), right_value.as_f64()) {
+        (Some(l), Some(r)) if cmp(l, r) => {
+            ConditionState::Matched(format!("{label} matched: {l} vs {r}"))
+        }
+        (Some(l), Some(r)) => ConditionState::Failed(format!("{label} failed: {l} vs {r}")),
+        _ => ConditionState::Failed(format!(
+            "{label} failed: unable to coerce {left_value:?} or {right_value:?} to numbers"
+        )),
+    }
+}
+
+impl ValueRef {
+    fn resolve(
+        &self,
+        context: &serde_json::Map<String, serde_json::Value>,
+        now: DateTime<Utc>,
+    ) -> serde_json::Value {
+        match self {
+            ValueRef::Literal { value } => value.clone(),
+            ValueRef::Context { path } => {
+                resolve_path(context, path).unwrap_or_else(|| match path.as_str() {
+                    "now" => serde_json::Value::String(now.to_rfc3339()),
+                    _ => serde_json::Value::Null,
+                })
+            }
+        }
+    }
+}
+
+fn resolve_path(
+    context: &serde_json::Map<String, serde_json::Value>,
+    path: &str,
+) -> Option<serde_json::Value> {
+    if let Some(value) = context.get(path) {
+        return Some(value.clone());
+    }
+    let mut iter = path.split('.');
+    let mut value = context.get(iter.next()?)?;
+    for part in iter {
+        match value {
+            serde_json::Value::Object(map) => {
+                value = map.get(part)?;
+            }
+            _ => return None,
+        }
+    }
+    Some(value.clone())
+}
+
+enum ConditionState {
+    Matched(String),
+    Failed(String),
+}
+
+async fn run_scheduler(state: AppState) {
+    let mut interval = tokio::time::interval(Duration::from_millis(TICK_INTERVAL_MS));
+    let mut tick: u64 = 0;
+    loop {
+        interval.tick().await;
+        tick = tick.wrapping_add(1);
+        let now = Utc::now();
+        let mut guard = state.rules.write();
+        for instance in guard.values_mut() {
+            if instance.schedule.should_fire(tick) {
+                let mut context = serde_json::Map::new();
+                context.insert(
+                    "now".to_string(),
+                    serde_json::Value::String(now.to_rfc3339()),
+                );
+                context.insert("tick".to_string(), serde_json::Value::Number(tick.into()));
+                let result = evaluate_rule(&instance.definition, &context, now);
+                if result.fired {
+                    tracing::info!(rule = %instance.definition.id, trace = ?result.trace, "rule fired");
+                } else {
+                    tracing::debug!(rule = %instance.definition.id, trace = ?result.trace, "rule skipped");
+                }
+                instance.schedule.advance();
+            }
+        }
+    }
+}
+
+impl ScheduleState {
+    fn new(trigger: &Trigger, current_tick: u64) -> Self {
+        match trigger {
+            Trigger::Interval { seconds } => {
+                let secs = (*seconds).max(1);
+                let interval_ms = secs * 1000;
+                let interval_ticks =
+                    ((interval_ms + TICK_INTERVAL_MS - 1) / TICK_INTERVAL_MS).max(1);
+                Self {
+                    next_tick: current_tick + interval_ticks,
+                    interval_ticks,
+                }
+            }
+            Trigger::Event { .. } => Self {
+                next_tick: u64::MAX,
+                interval_ticks: u64::MAX,
+            },
+        }
+    }
+
+    fn should_fire(&self, tick: u64) -> bool {
+        tick >= self.next_tick
+    }
+
+    fn advance(&mut self) {
+        if self.interval_ticks == u64::MAX {
+            self.next_tick = u64::MAX;
+        } else {
+            self.next_tick = self.next_tick.saturating_add(self.interval_ticks);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluate_rule_executes_when_conditions_match() {
+        let rule = RuleDefinition {
+            id: "rule-1".to_string(),
+            name: None,
+            trigger: Trigger::Interval { seconds: 1 },
+            conditions: vec![Condition::Equals {
+                left: ValueRef::Context {
+                    path: "temperature".to_string(),
+                },
+                right: ValueRef::Literal {
+                    value: serde_json::json!(72),
+                },
+            }],
+            actions: vec![Action::EmitEvent {
+                subject: "hvac.adjust".to_string(),
+                payload: serde_json::json!({"target": 70}),
+            }],
+        };
+
+        let mut context = serde_json::Map::new();
+        context.insert("temperature".to_string(), serde_json::json!(72));
+        let result = evaluate_rule(&rule, &context, Utc::now());
+        assert!(result.fired);
+        assert!(matches!(result.actions[0].status, ActionStatus::Executed));
+
+        context.insert("temperature".to_string(), serde_json::json!(68));
+        let result = evaluate_rule(&rule, &context, Utc::now());
+        assert!(!result.fired);
+        assert!(matches!(result.actions[0].status, ActionStatus::Skipped));
+    }
+
+    #[test]
+    fn schedule_state_advances_deterministically() {
+        let trigger = Trigger::Interval { seconds: 5 };
+        let mut schedule = ScheduleState::new(&trigger, 0);
+        let trigger_tick = ((5 * 1000 + TICK_INTERVAL_MS - 1) / TICK_INTERVAL_MS).max(1);
+        assert!(schedule.should_fire(trigger_tick));
+        let next_before = schedule.next_tick;
+        schedule.advance();
+        assert!(schedule.next_tick > next_before);
+    }
 }

--- a/services/scene-svc/Cargo.toml
+++ b/services/scene-svc/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { workspace = true }
-common-config = { workspace = true }
-common-obs = { workspace = true }
-tokio = { workspace = true }
+axum = { workspace = true, features = ["macros", "json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+common-config = { workspace = true }
+common-obs = { workspace = true }
+thiserror = { workspace = true }
+reqwest = { version = "0.11", features = ["json"] }
+async-trait = "0.1"

--- a/services/scene-svc/src/main.rs
+++ b/services/scene-svc/src/main.rs
@@ -1,14 +1,232 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
-use axum::Router;
+use async_trait::async_trait;
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tracing_subscriber::EnvFilter;
+
 use common_config::service_port;
 use common_obs::health_router;
-use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "scene-svc";
 const PORT_ENV: &str = "SCENE_SVC_PORT";
 const DEFAULT_PORT: u16 = 8003;
+const DEFAULT_REGISTRY_URL: &str = "http://127.0.0.1:8001";
+
+#[derive(Clone)]
+struct AppState<C: DeviceRegistryClient + Send + Sync + 'static> {
+    executor: Arc<SceneExecutor<C>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SceneRequest {
+    #[allow(dead_code)]
+    pub scene_id: Option<String>,
+    pub operations: Vec<DeviceOperation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DeviceOperation {
+    pub device_id: String,
+    pub state: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SceneResponse {
+    status: SceneStatus,
+    results: Vec<DeviceApplyResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SceneStatus {
+    Applied,
+    PartialFailure,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DeviceApplyResult {
+    device_id: String,
+    status: DeviceStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DeviceStatus {
+    Applied,
+    RolledBack,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SceneError {
+    #[error("registry unreachable: {0}")]
+    Registry(String),
+    #[error("device not found: {0}")]
+    Missing(String),
+    #[error("unexpected response")]
+    Unexpected,
+}
+
+#[async_trait]
+trait DeviceRegistryClient: Clone + Send + Sync {
+    async fn fetch_state(&self, device_id: &str) -> Result<serde_json::Value, SceneError>;
+    async fn apply_state(
+        &self,
+        device_id: &str,
+        state: &serde_json::Value,
+    ) -> Result<(), SceneError>;
+}
+
+#[derive(Clone)]
+struct HttpDeviceRegistry {
+    client: reqwest::Client,
+    base: String,
+}
+
+#[async_trait]
+impl DeviceRegistryClient for HttpDeviceRegistry {
+    async fn fetch_state(&self, device_id: &str) -> Result<serde_json::Value, SceneError> {
+        let url = format!("{}/v1/devices/{}", self.base, device_id);
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| SceneError::Registry(err.to_string()))?;
+        if response.status().is_success() {
+            let body: serde_json::Value = response
+                .json()
+                .await
+                .map_err(|err| SceneError::Registry(err.to_string()))?;
+            Ok(body
+                .get("state")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({})))
+        } else if response.status().as_u16() == 404 {
+            Err(SceneError::Missing(device_id.to_string()))
+        } else {
+            Err(SceneError::Unexpected)
+        }
+    }
+
+    async fn apply_state(
+        &self,
+        device_id: &str,
+        state: &serde_json::Value,
+    ) -> Result<(), SceneError> {
+        let url = format!("{}/v1/devices/{}/state", self.base, device_id);
+        let response = self
+            .client
+            .put(url)
+            .json(state)
+            .send()
+            .await
+            .map_err(|err| SceneError::Registry(err.to_string()))?;
+        if response.status().is_success() {
+            Ok(())
+        } else if response.status().as_u16() == 404 {
+            Err(SceneError::Missing(device_id.to_string()))
+        } else {
+            Err(SceneError::Unexpected)
+        }
+    }
+}
+
+struct SceneExecutor<C: DeviceRegistryClient> {
+    client: C,
+}
+
+impl<C: DeviceRegistryClient> SceneExecutor<C> {
+    async fn apply_scene(&self, request: SceneRequest) -> SceneResponse {
+        let mut results = Vec::with_capacity(request.operations.len());
+        let mut previous_states: Vec<(String, serde_json::Value)> = Vec::new();
+        let mut failure_encountered = false;
+
+        for op in &request.operations {
+            if failure_encountered {
+                results.push(DeviceApplyResult {
+                    device_id: op.device_id.clone(),
+                    status: DeviceStatus::Skipped,
+                    detail: Some("skipped due to prior failure".to_string()),
+                });
+                continue;
+            }
+
+            match self.client.fetch_state(&op.device_id).await {
+                Ok(prev) => match self.client.apply_state(&op.device_id, &op.state).await {
+                    Ok(_) => {
+                        previous_states.push((op.device_id.clone(), prev));
+                        results.push(DeviceApplyResult {
+                            device_id: op.device_id.clone(),
+                            status: DeviceStatus::Applied,
+                            detail: None,
+                        });
+                    }
+                    Err(err) => {
+                        failure_encountered = true;
+                        results.push(DeviceApplyResult {
+                            device_id: op.device_id.clone(),
+                            status: DeviceStatus::Failed,
+                            detail: Some(err.to_string()),
+                        });
+                    }
+                },
+                Err(err) => {
+                    failure_encountered = true;
+                    results.push(DeviceApplyResult {
+                        device_id: op.device_id.clone(),
+                        status: DeviceStatus::Failed,
+                        detail: Some(err.to_string()),
+                    });
+                }
+            }
+        }
+
+        if failure_encountered {
+            for (device_id, prev_state) in previous_states.into_iter().rev() {
+                if let Err(err) = self.client.apply_state(&device_id, &prev_state).await {
+                    results.push(DeviceApplyResult {
+                        device_id,
+                        status: DeviceStatus::Failed,
+                        detail: Some(format!("rollback failed: {err}")),
+                    });
+                } else {
+                    results.push(DeviceApplyResult {
+                        device_id,
+                        status: DeviceStatus::RolledBack,
+                        detail: Some("rolled back".to_string()),
+                    });
+                }
+            }
+        }
+
+        let status = if failure_encountered {
+            if results
+                .iter()
+                .any(|r| matches!(r.status, DeviceStatus::RolledBack))
+            {
+                SceneStatus::PartialFailure
+            } else {
+                SceneStatus::Failed
+            }
+        } else {
+            SceneStatus::Applied
+        };
+
+        SceneResponse { status, results }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,9 +234,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let registry_url =
+        std::env::var("DEVICE_REGISTRY_URL").unwrap_or_else(|_| DEFAULT_REGISTRY_URL.to_string());
+
+    let client = HttpDeviceRegistry {
+        client: reqwest::Client::new(),
+        base: registry_url,
+    };
+
+    let state = AppState {
+        executor: Arc::new(SceneExecutor { client }),
+    };
+
     tracing::info!(%addr, service = SERVICE_NAME, "starting service");
 
-    let app = Router::new().merge(health_router(SERVICE_NAME));
+    let app = Router::new()
+        .route("/v1/scenes:apply", post(apply_scene))
+        .with_state(state)
+        .merge(health_router(SERVICE_NAME));
 
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service()).await?;
@@ -29,4 +262,86 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+async fn apply_scene<C: DeviceRegistryClient + Send + Sync + 'static>(
+    State(state): State<AppState<C>>,
+    Json(payload): Json<SceneRequest>,
+) -> Json<SceneResponse> {
+    let response = state.executor.apply_scene(payload).await;
+    Json(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct MockRegistry {
+        devices: Arc<Mutex<HashMap<String, serde_json::Value>>>,
+        fail_on: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl DeviceRegistryClient for MockRegistry {
+        async fn fetch_state(&self, device_id: &str) -> Result<serde_json::Value, SceneError> {
+            let devices = self.devices.lock().await;
+            devices
+                .get(device_id)
+                .cloned()
+                .ok_or_else(|| SceneError::Missing(device_id.to_string()))
+        }
+
+        async fn apply_state(
+            &self,
+            device_id: &str,
+            state: &serde_json::Value,
+        ) -> Result<(), SceneError> {
+            if let Some(failing) = self.fail_on.lock().await.clone() {
+                if failing == device_id {
+                    return Err(SceneError::Registry("simulated failure".to_string()));
+                }
+            }
+            let mut devices = self.devices.lock().await;
+            devices.insert(device_id.to_string(), state.clone());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn scene_rolls_back_on_failure() {
+        let registry = MockRegistry::default();
+        {
+            let mut devices = registry.devices.lock().await;
+            devices.insert("one".to_string(), serde_json::json!({"power": "off"}));
+            devices.insert("two".to_string(), serde_json::json!({"power": "off"}));
+        }
+        *registry.fail_on.lock().await = Some("two".to_string());
+
+        let executor = SceneExecutor {
+            client: registry.clone(),
+        };
+        let response = executor
+            .apply_scene(SceneRequest {
+                scene_id: None,
+                operations: vec![
+                    DeviceOperation {
+                        device_id: "one".to_string(),
+                        state: serde_json::json!({"power": "on"}),
+                    },
+                    DeviceOperation {
+                        device_id: "two".to_string(),
+                        state: serde_json::json!({"power": "on"}),
+                    },
+                ],
+            })
+            .await;
+
+        assert!(matches!(response.status, SceneStatus::PartialFailure));
+        let applied = response
+            .results
+            .iter()
+            .find(|r| r.device_id == "one" && matches!(r.status, DeviceStatus::RolledBack));
+        assert!(applied.is_some(), "device one should have been rolled back");
+    }
 }


### PR DESCRIPTION
## Summary
- implement a sqlx-backed device registry with CRUD APIs, capability management, and streaming updates over SSE/WebSockets
- add a rule engine with a JSON DSL, deterministic scheduler loop, and a /v1/rules:test dry-run endpoint
- deliver transactional scene application against the registry along with presence, energy, and audit services plus targeted unit tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d5bfe26be8832f9688ba075ceb0340