### PR TITLE
feat: enable structured logging and build metadata across services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
  "tokio",
  "tower 0.4.13",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -172,7 +171,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -696,7 +694,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -788,7 +785,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2015,7 +2011,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2065,7 +2060,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2230,7 +2224,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -2395,7 +2388,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2967,7 +2959,6 @@ dependencies = [
  "common-obs",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3369,7 +3360,6 @@ dependencies = [
  "common-obs",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,24 @@
 .PHONY: help fmt lint test build e2e package sbom
 
+BUILD_SHA ?= $(shell git rev-parse --short HEAD)
+BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+CARGO_ENV = BUILD_SHA=$(BUILD_SHA) BUILD_TIME=$(BUILD_TIME)
+
 help:
 @echo "Available targets: fmt lint test build e2e package sbom"
 
 fmt:
-cargo fmt --all
+$(CARGO_ENV) cargo fmt --all
 
 lint:
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+$(CARGO_ENV) cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 test:
-cargo test --workspace --all-targets
+$(CARGO_ENV) cargo test --workspace --all-targets
 
 build:
-cargo build --workspace --all-targets
+$(CARGO_ENV) cargo build --workspace --all-targets
 
 e2e:
 @echo "e2e tests are not implemented yet"

--- a/services/api-gateway/Cargo.toml
+++ b/services/api-gateway/Cargo.toml
@@ -21,7 +21,6 @@ serde_yaml = "0.9"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 rand = "0.8"
 uuid = { version = "1", features = ["v4"] }
 once_cell = "1.19"

--- a/services/api-gateway/src/main.rs
+++ b/services/api-gateway/src/main.rs
@@ -16,13 +16,31 @@ use rustls::server::WebPkiClientVerifier;
 use rustls::{RootCertStore, ServerConfig as RustlsServerConfig};
 use tokio::fs;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn build_sha() -> &'static str {
+    option_env!("BUILD_SHA").unwrap_or("unknown")
+}
+
+fn build_time() -> &'static str {
+    option_env!("BUILD_TIME").unwrap_or("unknown")
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ObsInit::init(SERVICE_NAME).map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
 
     let config = load::<ApiGatewayConfig>()?;
     let addr = config.socket_addr()?;
-    tracing::info!(event = "service_start", service = SERVICE_NAME, %addr);
+    tracing::info!(
+        event = "service_start",
+        service = SERVICE_NAME,
+        version = VERSION,
+        build_sha = build_sha(),
+        build_time = build_time(),
+        listen_addr = %addr,
+        "starting service"
+    );
 
     let bus_config = NatsConfig {
         url: config.bus.url.clone(),

--- a/services/audit-log/Cargo.toml
+++ b/services/audit-log/Cargo.toml
@@ -9,7 +9,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "sync"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 common-config = { workspace = true }
 common-obs = { workspace = true }
 sha2 = "0.10"

--- a/services/device-registry/Cargo.toml
+++ b/services/device-registry/Cargo.toml
@@ -15,7 +15,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 uuid = { version = "1", features = ["serde", "v4"] }
 common-config = { workspace = true }
 common-obs = { workspace = true }

--- a/services/energy-svc/Cargo.toml
+++ b/services/energy-svc/Cargo.toml
@@ -9,7 +9,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 common-config = { workspace = true }
 common-obs = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }

--- a/services/energy-svc/src/main.rs
+++ b/services/energy-svc/src/main.rs
@@ -9,14 +9,23 @@ use chrono::{DateTime, Local, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
-use tracing_subscriber::EnvFilter;
 
 use common_config::service_port;
-use common_obs::health_router;
+use common_obs::{health_router, ObsInit};
 
 const SERVICE_NAME: &str = "energy-svc";
 const PORT_ENV: &str = "ENERGY_SVC_PORT";
 const DEFAULT_PORT: u16 = 8005;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn build_sha() -> &'static str {
+    option_env!("BUILD_SHA").unwrap_or("unknown")
+}
+
+fn build_time() -> &'static str {
+    option_env!("BUILD_TIME").unwrap_or("unknown")
+}
 
 #[derive(Clone)]
 struct AppState {
@@ -75,7 +84,7 @@ struct AdviceResponse {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    init_tracing();
+    ObsInit::init(SERVICE_NAME).map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -84,7 +93,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         state: Arc::new(RwLock::new(EnergyState::default())),
     };
 
-    tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+    tracing::info!(
+        event = "service_start",
+        service = SERVICE_NAME,
+        version = VERSION,
+        build_sha = build_sha(),
+        build_time = build_time(),
+        listen_addr = %addr,
+        "starting service"
+    );
 
     let app = Router::new()
         .route("/v1/budgets", post(set_budgets))
@@ -97,11 +114,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
-}
-
-fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
 
 async fn set_budgets(

--- a/services/presence-svc/Cargo.toml
+++ b/services/presence-svc/Cargo.toml
@@ -9,7 +9,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 common-config = { workspace = true }
 common-obs = { workspace = true }
 common-msgbus = { workspace = true }

--- a/services/presence-svc/src/main.rs
+++ b/services/presence-svc/src/main.rs
@@ -12,14 +12,23 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
-use tracing_subscriber::EnvFilter;
 
 use common_config::service_port;
-use common_obs::health_router;
+use common_obs::{health_router, ObsInit};
 
 const SERVICE_NAME: &str = "presence-svc";
 const PORT_ENV: &str = "PRESENCE_SVC_PORT";
 const DEFAULT_PORT: u16 = 8004;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn build_sha() -> &'static str {
+    option_env!("BUILD_SHA").unwrap_or("unknown")
+}
+
+fn build_time() -> &'static str {
+    option_env!("BUILD_TIME").unwrap_or("unknown")
+}
 
 #[derive(Clone)]
 struct AppState {
@@ -67,7 +76,7 @@ fn default_confidence() -> f32 {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    init_tracing();
+    ObsInit::init(SERVICE_NAME).map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -75,7 +84,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (tx, _) = broadcast::channel(128);
     let state = AppState { events: tx };
 
-    tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+    tracing::info!(
+        event = "service_start",
+        service = SERVICE_NAME,
+        version = VERSION,
+        build_sha = build_sha(),
+        build_time = build_time(),
+        listen_addr = %addr,
+        "starting service"
+    );
 
     let app = Router::new()
         .route("/v1/presence/webhook", post(intake_webhook))
@@ -88,11 +105,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
-}
-
-fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
 
 async fn intake_webhook(

--- a/services/radio-coord/Cargo.toml
+++ b/services/radio-coord/Cargo.toml
@@ -13,4 +13,3 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }

--- a/services/rule-engine/Cargo.toml
+++ b/services/rule-engine/Cargo.toml
@@ -12,7 +12,6 @@ common-msgbus = { workspace = true }
 common-obs = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/scene-svc/Cargo.toml
+++ b/services/scene-svc/Cargo.toml
@@ -9,7 +9,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 common-config = { workspace = true }
 common-obs = { workspace = true }
 thiserror = { workspace = true }

--- a/services/telemetry-pipe/Cargo.toml
+++ b/services/telemetry-pipe/Cargo.toml
@@ -9,4 +9,3 @@ common-config = { workspace = true }
 common-obs = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }

--- a/services/telemetry-pipe/src/main.rs
+++ b/services/telemetry-pipe/src/main.rs
@@ -2,21 +2,38 @@ use std::net::SocketAddr;
 
 use axum::Router;
 use common_config::service_port;
-use common_obs::health_router;
+use common_obs::{health_router, ObsInit};
 use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "telemetry-pipe";
 const PORT_ENV: &str = "TELEMETRY_PIPE_PORT";
 const DEFAULT_PORT: u16 = 8007;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn build_sha() -> &'static str {
+    option_env!("BUILD_SHA").unwrap_or("unknown")
+}
+
+fn build_time() -> &'static str {
+    option_env!("BUILD_TIME").unwrap_or("unknown")
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    init_tracing();
+    ObsInit::init(SERVICE_NAME).map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+    tracing::info!(
+        event = "service_start",
+        service = SERVICE_NAME,
+        version = VERSION,
+        build_sha = build_sha(),
+        build_time = build_time(),
+        listen_addr = %addr,
+        "starting service"
+    );
 
     let app = Router::new().merge(health_router(SERVICE_NAME));
 
@@ -24,9 +41,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
-}
-
-fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }

--- a/services/updater/Cargo.toml
+++ b/services/updater/Cargo.toml
@@ -9,4 +9,3 @@ common-config = { workspace = true }
 common-obs = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }

--- a/services/updater/src/main.rs
+++ b/services/updater/src/main.rs
@@ -2,21 +2,38 @@ use std::net::SocketAddr;
 
 use axum::Router;
 use common_config::service_port;
-use common_obs::health_router;
+use common_obs::{health_router, ObsInit};
 use tokio::net::TcpListener;
-use tracing_subscriber::EnvFilter;
 
 const SERVICE_NAME: &str = "updater";
 const PORT_ENV: &str = "UPDATER_PORT";
 const DEFAULT_PORT: u16 = 8006;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn build_sha() -> &'static str {
+    option_env!("BUILD_SHA").unwrap_or("unknown")
+}
+
+fn build_time() -> &'static str {
+    option_env!("BUILD_TIME").unwrap_or("unknown")
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    init_tracing();
+    ObsInit::init(SERVICE_NAME).map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
 
     let port = service_port(PORT_ENV, DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!(%addr, service = SERVICE_NAME, "starting service");
+    tracing::info!(
+        event = "service_start",
+        service = SERVICE_NAME,
+        version = VERSION,
+        build_sha = build_sha(),
+        build_time = build_time(),
+        listen_addr = %addr,
+        "starting service"
+    );
 
     let app = Router::new().merge(health_router(SERVICE_NAME));
 
@@ -24,9 +41,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
-}
-
-fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }


### PR DESCRIPTION
## Summary
- initialize `common_obs::ObsInit` in every service binary and replace ad-hoc tracing setup
- emit consistent `service_start` logs carrying service name, version, build SHA, build time, and listen address across binaries
- inject `BUILD_SHA` and `BUILD_TIME` via the Makefile so services can reference the values at compile time

## Testing
- cargo fmt
- cargo test --workspace --all-targets *(fails: unresolved import `common_obs::health_router`)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d4698c48832f90053689678730cf