### PR TITLE
feat(diag): add diag endpoints to gateway, rules, radio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,10 +2054,12 @@ name = "radio-coord"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "common-config",
  "common-mdns",
  "common-msgbus",
  "common-obs",
+ "parking_lot",
  "serde",
  "serde_json",
  "tokio",

--- a/configs/rbac.yaml
+++ b/configs/rbac.yaml
@@ -16,6 +16,14 @@ routes:
     methods: [GET]
     roles: [guest]
     audit_action: system.info
+  - pattern: /v1/diag/ping
+    methods: [GET]
+    roles: [admin, owner]
+    audit_action: diag.ping
+  - pattern: /v1/diag/routes
+    methods: [GET]
+    roles: [admin, owner]
+    audit_action: diag.routes
   - pattern: /v1/devices
     methods: [GET]
     roles: [member, admin, owner]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -39,3 +39,24 @@ api_gateway_requests_inflight <count>
 
 The uptime value is computed from the process start time, and the counters are
 maintained by the request middleware that wraps every route.
+
+## Diagnostics endpoints
+
+To assist operators during incident response every control-plane service now
+exposes lightweight diagnostic endpoints under the `/v1/diag/*` namespace:
+
+* **API Gateway**
+  * `GET /v1/diag/ping?target=<host>[&port=]` performs a TCP reachability probe
+    and reports timing, resolution details, and errors.
+  * `GET /v1/diag/routes` returns the RBAC policy surface paired with the
+    required roles for each protected route along with public routes.
+* **Rule Engine** – `GET /v1/diag/trace?rule_id=<id>` surfaces the most recent
+  executions (up to 100) for a rule, including decision outcomes and runtime
+  durations.
+* **Radio Coordinator** – `GET /v1/diag/radio-map` snapshots the most recently
+  applied Thread and Wi-Fi channels/configuration without contacting field
+  hardware.
+
+These endpoints are lightweight, require authentication, and integrate with the
+existing observability middleware so access attempts and latencies remain
+visible in logs and metrics.

--- a/services/radio-coord/Cargo.toml
+++ b/services/radio-coord/Cargo.toml
@@ -13,3 +13,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+parking_lot = "0.12"


### PR DESCRIPTION
## Summary
- add gateway diagnostics for TCP ping probes and RBAC route summaries protected by RBAC policy updates
- capture in-memory execution traces in rule-engine and expose them via /v1/diag/trace with a 100-entry cap
- maintain a thread/wifi radio snapshot in radio-coord, provide a /v1/diag/radio-map endpoint, and document the new diagnostics surface

## Testing
- cargo test -p api-gateway
- cargo test -p rule-engine
- cargo test -p radio-coord

------
https://chatgpt.com/codex/tasks/task_e_68d5dbc296d0832f9ba144bf66af56b0