### PR TITLE
feat(obs-docs): grafana dashboards, prometheus alerts, sdk docs

### DIFF
--- a/alerts/prometheus/observability-alerts.yaml
+++ b/alerts/prometheus/observability-alerts.yaml
@@ -1,0 +1,43 @@
+groups:
+  - name: lokan-platform
+    interval: 1m
+    rules:
+      - alert: LokanHighErrorRate
+        expr: |
+          (
+            sum by (service, env)(rate(lokan_http_requests_total{status=~"5.."}[5m]))
+            /
+            sum by (service, env)(rate(lokan_http_requests_total[5m]))
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: page
+          team: lokan-platform
+        annotations:
+          summary: "High HTTP error rate"
+          description: |
+            5xx errors exceed 2% of total requests for the last 5 minutes in {{ $labels.service }} (env {{ $labels.env }}).
+      - alert: LokanLatencySLOBreach
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le, service, env)(rate(lokan_http_request_duration_seconds_bucket[5m]))
+          ) > 0.75
+        for: 10m
+        labels:
+          severity: page
+          team: lokan-platform
+        annotations:
+          summary: "p95 latency above 750ms"
+          description: |
+            p95 latency for {{ $labels.service }} in {{ $labels.env }} has exceeded 750ms for the last 10 minutes.
+      - alert: LokanMetricsScrapeMissing
+        expr: up{job=~"lokan-.*"} == 0
+        for: 5m
+        labels:
+          severity: ticket
+          team: lokan-observability
+        annotations:
+          summary: "Prometheus scrape missing"
+          description: |
+            Prometheus scrape target {{ $labels.job }} (env {{ $labels.env }}) has been down or missing for 5 minutes.

--- a/dashboards/grafana/device-registry.json
+++ b/dashboards/grafana/device-registry.json
@@ -1,0 +1,228 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(lokan_device_registry_requests_total{verb=\"create\",env=~\"$environment\"}[5m]))",
+          "legendFormat": "Create",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(lokan_device_registry_requests_total{verb=\"read\",env=~\"$environment\"}[5m]))",
+          "legendFormat": "Read",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(lokan_device_registry_requests_total{verb=\"update\",env=~\"$environment\"}[5m]))",
+          "legendFormat": "Update",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(lokan_device_registry_requests_total{verb=\"delete\",env=~\"$environment\"}[5m]))",
+          "legendFormat": "Delete",
+          "refId": "D"
+        }
+      ],
+      "title": "Device Registry CRUD Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "msg/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(lokan_device_registry_subscription_fanout_total{env=~\"$environment\"}[5m]))",
+          "legendFormat": "Fanout deliveries",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(lokan_device_registry_subscription_failures_total{env=~\"$environment\"}[5m]))",
+          "legendFormat": "Fanout failures",
+          "refId": "B"
+        }
+      ],
+      "title": "Subscription Fanout",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "targets": [
+        {
+          "expr": "sum(lokan_device_registry_pending_subscriptions{env=~\"$environment\"})",
+          "legendFormat": "Pending subscriptions",
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Subscription Backlog",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "lokan",
+    "device-registry"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prod",
+          "value": "prod"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(lokan_device_registry_requests_total, env)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": {
+          "query": "label_values(lokan_device_registry_requests_total, env)",
+          "refId": "Prometheus-environment-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "browser",
+  "title": "Device Registry",
+  "uid": "lokan-device-registry",
+  "version": 1
+}

--- a/dashboards/grafana/lokan-overview.json
+++ b/dashboards/grafana/lokan-overview.json
@@ -1,0 +1,338 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(lokan_http_requests_total{service!~\".*-canary\",env=~\"$environment\"}[5m]))",
+          "interval": "",
+          "legendFormat": "All services",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(lokan_http_requests_total{service=\"api-gateway\",env=~\"$environment\"}[5m]))",
+          "hide": false,
+          "legendFormat": "API Gateway",
+          "refId": "B"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(lokan_http_requests_total{status=~\"5..\",env=~\"$environment\"}[5m])) / sum(rate(lokan_http_requests_total{env=~\"$environment\"}[5m]))",
+          "interval": "",
+          "legendFormat": "5xx error %",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * sum(rate(lokan_http_requests_total{status=~\"4..\",env=~\"$environment\"}[5m])) / sum(rate(lokan_http_requests_total{env=~\"$environment\"}[5m]))",
+          "interval": "",
+          "legendFormat": "4xx error %",
+          "refId": "B"
+        }
+      ],
+      "title": "Error Percentage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "1000 * histogram_quantile(0.95, sum(rate(lokan_http_request_duration_seconds_bucket{env=~\"$environment\"}[5m])) by (le))",
+          "legendFormat": "HTTP p95",
+          "refId": "A"
+        },
+        {
+          "expr": "1000 * histogram_quantile(0.95, sum(rate(lokan_rule_eval_duration_seconds_bucket{env=~\"$environment\"}[5m])) by (le))",
+          "legendFormat": "Rule engine p95",
+          "refId": "B"
+        }
+      ],
+      "title": "p95 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "state"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "targets": [
+        {
+          "expr": "avg(lokan_updater_health_status{env=~\"$environment\",status=\"healthy\"})",
+          "legendFormat": "Updater healthy",
+          "refId": "A"
+        }
+      ],
+      "title": "Updater Health",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(lokan_rule_engine_ticks_total{env=~\"$environment\"}[5m]))",
+          "legendFormat": "Ticks/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Rule Engine Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Optional energy service visibility when deployed.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg(lokan_energy_service_power_draw_watts{env=~\"$environment\"})",
+          "legendFormat": "Power draw",
+          "refId": "A"
+        }
+      ],
+      "title": "Energy Service Power Draw",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "lokan",
+    "overview"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prod",
+          "value": "prod"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(lokan_http_requests_total, env)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": {
+          "query": "label_values(lokan_http_requests_total, env)",
+          "refId": "Prometheus-environment-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "browser",
+  "title": "Lokan Overview",
+  "uid": "lokan-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -1,0 +1,100 @@
+# API & SDK Overview
+
+LokanOS surfaces its control plane through HTTPS JSON APIs fronted by the API
+Gateway. Most teams integrate with one of the provided SDKs instead of managing
+raw HTTP requests. The SDKs handle URL composition, TLS configuration, and error
+parsing so applications can focus on business logic.
+
+## TypeScript SDK quickstart
+
+The TypeScript SDK lives in `sdks/typescript` and is published as a local package
+for internal builds. To use it in a Node.js or browser project:
+
+```bash
+npm install file:../sdks/typescript
+```
+
+Create a thin client instance by passing the API base URL and any shared headers
+(such as authentication tokens). The generator exposes one function per API
+operation; responses already include strong typing via the exported interfaces.
+
+```ts
+import { apiGatewayHealth, telemetryPipeIngest } from '@lokanos/sdk';
+
+const clientOptions = {
+  baseUrl: 'https://api.lokan.example',
+  headers: {
+    Authorization: `Bearer ${process.env.LOKAN_TOKEN}`,
+  },
+};
+
+async function main() {
+  const status = await apiGatewayHealth(clientOptions);
+  console.log('Gateway status:', status);
+
+  await telemetryPipeIngest(
+    {
+      source: 'lab-sensor-42',
+      payload: { temperature_c: 23.4 },
+    },
+    clientOptions,
+  );
+}
+
+main().catch((err) => {
+  console.error('Lokan call failed', err);
+  process.exitCode = 1;
+});
+```
+
+The SDK defaults to `globalThis.fetch`; supply a polyfill (e.g. `node-fetch`) in
+older environments via the `fetch` option on each call.
+
+## C SDK quickstart
+
+Embedded clients can depend on the C SDK located in `sdks/c`. The library uses
+libcurl under the hood and exposes a minimal surface for health checks and scene
+application.
+
+1. Add the SDK as a subdirectory in your CMake project:
+
+   ```cmake
+   add_subdirectory(${CMAKE_SOURCE_DIR}/sdks/c ${CMAKE_BINARY_DIR}/lokan-sdk)
+   target_link_libraries(your_app PRIVATE lokan-sdk)
+   ```
+
+2. Initialize the client with the proper TLS credentials and perform calls:
+
+   ```c
+   #include <lokan.h>
+
+   int main(void) {
+       lokan_client_t *client = NULL;
+       lokan_client_config_t cfg = {
+           .base_url = "https://api.lokan.example",
+           .client_cert_path = "/etc/lokan/device.crt",
+           .client_key_path = "/etc/lokan/device.key",
+           .ca_cert_path = "/etc/ssl/certs/ca-certificates.crt",
+           .timeout_ms = 5000,
+       };
+
+       if (lokan_client_init(&client, &cfg) != LOKAN_OK) {
+           fprintf(stderr, "Failed to init Lokan client\n");
+           return 1;
+       }
+
+       char *health_json = NULL;
+       if (lokan_get_health(client, &health_json) == LOKAN_OK) {
+           printf("Health: %s\n", health_json);
+       }
+       lokan_string_free(health_json);
+
+       const char *scene_payload = "{\\"brightness\\":75}";
+       lokan_apply_scene(client, "scene-lab-demo", scene_payload);
+
+       lokan_client_cleanup(client);
+       return 0;
+   }
+   ```
+
+Check the `sdks/c/examples/` directory for a complete buildable reference.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,3 +60,39 @@ exposes lightweight diagnostic endpoints under the `/v1/diag/*` namespace:
 These endpoints are lightweight, require authentication, and integrate with the
 existing observability middleware so access attempts and latencies remain
 visible in logs and metrics.
+
+## Grafana dashboards
+
+Two curated Grafana dashboards live under `dashboards/grafana/` ready for import
+into a Lokan Grafana instance:
+
+* **Lokan Overview** (`lokan-overview.json`) brings together the top platform
+  signals—request rate, aggregate error percentage, HTTP and rule-engine p95
+  latency, updater health, rule engine throughput, and an optional energy
+  service power-draw panel. The dashboard templatizes the `env` label so teams
+  can pivot between production, staging, and on-site clusters without editing
+  queries.
+* **Device Registry** (`device-registry.json`) focuses on registry CRUD volume,
+  subscription fan-out throughput vs. failures, and the size of the pending
+  subscription backlog. The panel layout highlights saturation patterns when
+  writes or fan-out begin to queue.
+
+Exported JSON files adhere to Grafana schema v38 and assume a Prometheus data
+source (`${DS_PROMETHEUS}`) is available.
+
+## Prometheus alerting rules
+
+Operator playbooks rely on the alert bundle in
+`alerts/prometheus/observability-alerts.yaml`. The rules cover three high value
+signals:
+
+* **LokanHighErrorRate**: Pages when 5xx responses exceed 2% of request volume
+  for a given service/environment pair across five minutes.
+* **LokanLatencySLOBreach**: Tracks the shared 750 ms p95 HTTP latency SLO per
+  service and raises a page if it is breached for ten minutes.
+* **LokanMetricsScrapeMissing**: Files a ticket when any `lokan-*` scrape target
+  is absent from Prometheus for at least five minutes, catching exporter or
+  endpoint regressions quickly.
+
+Drop the YAML file into an alertmanager-enabled Prometheus installation and
+reload to activate the rules.


### PR DESCRIPTION
## Summary
- add import-ready Grafana dashboards covering platform overview metrics and device registry throughput
- ship Prometheus alert rules for error rates, latency SLO, and scrape health
- document observability assets plus TypeScript and C SDK quickstarts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ec541558832fbc1bd384bb92aa75