### PR TITLE
feat(updater): A/B state machine, health contract, transition tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,10 +3359,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "updater"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "common-config",
  "common-obs",
  "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]

--- a/services/updater/Cargo.toml
+++ b/services/updater/Cargo.toml
@@ -4,11 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { workspace = true }
+async-trait = "0.1"
+axum = { workspace = true, features = ["macros", "json"] }
 common-config = { workspace = true }
 common-obs = { workspace = true }
-tokio = { workspace = true }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "fs", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/services/updater/src/core.rs
+++ b/services/updater/src/core.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+
+use crate::health::{HealthCheckError, HealthClient};
+use crate::state::{CommitError, RollbackError, Slot, StageError, UpdaterState};
+use crate::store::{StateStore, StateStoreError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum UpdaterError {
+    #[error(transparent)]
+    Stage(#[from] StageError),
+    #[error(transparent)]
+    Commit(#[from] CommitError),
+    #[error(transparent)]
+    Rollback(#[from] RollbackError),
+    #[error(transparent)]
+    Store(#[from] StateStoreError),
+    #[error(transparent)]
+    Health(#[from] HealthCheckError),
+    #[error("health check quorum not satisfied before deadline")]
+    HealthQuorumFailed,
+}
+
+#[derive(Clone)]
+pub struct UpdaterCore {
+    state: Arc<Mutex<UpdaterState>>,
+    store: Arc<dyn StateStore>,
+    health_client: Arc<dyn HealthClient>,
+    health_endpoints: Arc<Vec<String>>,
+    health_deadline: Duration,
+    health_quorum: usize,
+}
+
+impl UpdaterCore {
+    pub async fn new(
+        store: Arc<dyn StateStore>,
+        health_client: Arc<dyn HealthClient>,
+        health_endpoints: Vec<String>,
+        health_deadline: Duration,
+        health_quorum: usize,
+    ) -> Result<Self, UpdaterError> {
+        let state = match store.load().await? {
+            Some(state) => state,
+            None => UpdaterState::default(),
+        };
+
+        Ok(Self {
+            state: Arc::new(Mutex::new(state)),
+            store,
+            health_client,
+            health_endpoints: Arc::new(health_endpoints),
+            health_deadline,
+            health_quorum,
+        })
+    }
+
+    pub async fn state(&self) -> UpdaterState {
+        self.state.lock().await.clone()
+    }
+
+    pub async fn stage(&self, artifact: String) -> Result<Slot, UpdaterError> {
+        let mut state = self.state.lock().await;
+        let slot = state.stage(artifact)?;
+        self.store.save(&state).await?;
+        Ok(slot)
+    }
+
+    pub async fn commit_on_health(&self) -> Result<Slot, UpdaterError> {
+        let slot = {
+            let mut state = self.state.lock().await;
+            let slot = state.begin_commit()?;
+            self.store.save(&state).await?;
+            slot
+        };
+
+        let healthy = self
+            .health_client
+            .wait_for_quorum(
+                self.health_endpoints.as_ref(),
+                self.health_deadline,
+                self.health_quorum,
+            )
+            .await?;
+
+        let mut state = self.state.lock().await;
+        if healthy {
+            state.finalize_commit(slot);
+            self.store.save(&state).await?;
+            Ok(slot)
+        } else {
+            state.fail_commit(slot);
+            self.store.save(&state).await?;
+            Err(UpdaterError::HealthQuorumFailed)
+        }
+    }
+
+    pub async fn mark_bad(&self) -> Result<Option<Slot>, UpdaterError> {
+        let mut state = self.state.lock().await;
+        let result = state.mark_active_bad();
+        self.store.save(&state).await?;
+        Ok(result)
+    }
+
+    pub async fn rollback(&self) -> Result<Slot, UpdaterError> {
+        let mut state = self.state.lock().await;
+        let slot = state.rollback()?;
+        self.store.save(&state).await?;
+        Ok(slot)
+    }
+}

--- a/services/updater/src/health.rs
+++ b/services/updater/src/health.rs
@@ -1,0 +1,106 @@
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use tokio::time::sleep;
+
+#[derive(Debug, thiserror::Error)]
+pub enum HealthCheckError {
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+}
+
+#[async_trait]
+pub trait HealthClient: Send + Sync {
+    async fn wait_for_quorum(
+        &self,
+        endpoints: &[String],
+        deadline: Duration,
+        quorum: usize,
+    ) -> Result<bool, HealthCheckError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpHealthClient {
+    client: Client,
+    poll_interval: Duration,
+}
+
+impl Default for HttpHealthClient {
+    fn default() -> Self {
+        Self::new(Duration::from_millis(250))
+    }
+}
+
+impl HttpHealthClient {
+    pub fn new(poll_interval: Duration) -> Self {
+        Self {
+            client: Client::builder().build().expect("reqwest client"),
+            poll_interval,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct HealthResponse {
+    status: String,
+}
+
+#[async_trait]
+impl HealthClient for HttpHealthClient {
+    async fn wait_for_quorum(
+        &self,
+        endpoints: &[String],
+        deadline: Duration,
+        quorum: usize,
+    ) -> Result<bool, HealthCheckError> {
+        if quorum == 0 || endpoints.is_empty() {
+            return Ok(true);
+        }
+
+        let quorum = quorum.min(endpoints.len());
+        let deadline_at = Instant::now() + deadline;
+
+        loop {
+            let mut healthy = 0;
+            for endpoint in endpoints {
+                let response = self.client.get(endpoint).send().await?.error_for_status()?;
+
+                if response.status().is_success() {
+                    match response.json::<HealthResponse>().await {
+                        Ok(body) if body.status.eq_ignore_ascii_case("ok") => healthy += 1,
+                        _ => {}
+                    }
+                }
+            }
+
+            if healthy >= quorum {
+                return Ok(true);
+            }
+
+            if Instant::now() >= deadline_at {
+                return Ok(false);
+            }
+
+            sleep(self.poll_interval).await;
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct StubHealthClient {
+    pub result: bool,
+}
+
+#[async_trait]
+impl HealthClient for StubHealthClient {
+    async fn wait_for_quorum(
+        &self,
+        _endpoints: &[String],
+        _deadline: Duration,
+        _quorum: usize,
+    ) -> Result<bool, HealthCheckError> {
+        Ok(self.result)
+    }
+}

--- a/services/updater/src/lib.rs
+++ b/services/updater/src/lib.rs
@@ -1,19 +1,33 @@
 use std::net::SocketAddr;
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use axum::body::Body;
-use axum::extract::MatchedPath;
+use axum::extract::{MatchedPath, State};
 use axum::http::{header, HeaderValue, Request, StatusCode};
 use axum::middleware::{from_fn, Next};
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
-use axum::Router;
+use axum::routing::{get, post};
+use axum::{Json, Router};
 use common_config::service_port;
 use common_obs::{
-    encode_prometheus_metrics, health_router, http_request_observe, ObsInit, ObsInitError,
-    PROMETHEUS_CONTENT_TYPE,
+    encode_prometheus_metrics, http_request_observe, ObsInit, ObsInitError, PROMETHEUS_CONTENT_TYPE,
 };
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
+
+mod core;
+mod health;
+mod state;
+mod store;
+
+pub use crate::core::{UpdaterCore, UpdaterError};
+pub use crate::health::{HealthCheckError, HealthClient, StubHealthClient};
+pub use crate::state::{Slot, SlotState, UpdaterState};
+pub use crate::store::{FileStateStore, MemoryStateStore, StateStore};
+
+use crate::health::HttpHealthClient;
+use crate::state::{CommitError, StageError};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: &str = match option_env!("BUILD_SHA") {
@@ -28,6 +42,11 @@ const BUILD_TIME: &str = match option_env!("BUILD_TIME") {
 pub const SERVICE_NAME: &str = "updater";
 pub const PORT_ENV: &str = "UPDATER_PORT";
 pub const DEFAULT_PORT: u16 = 8006;
+const DEFAULT_STATE_PATH: &str = "data/updater/state.json";
+const HEALTH_DEADLINE_ENV: &str = "UPDATER_HEALTH_DEADLINE_SECS";
+const HEALTH_ENDPOINTS_ENV: &str = "UPDATER_HEALTH_ENDPOINTS";
+const HEALTH_QUORUM_ENV: &str = "UPDATER_HEALTH_QUORUM";
+const DEFAULT_HEALTH_DEADLINE: Duration = Duration::from_secs(30);
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     ObsInit::init(SERVICE_NAME).map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
@@ -48,16 +67,33 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
-    let app = build_router();
+    let app = build_router()
+        .await
+        .map_err(|err| -> Box<dyn std::error::Error> { Box::new(err) })?;
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service()).await?;
     Ok(())
 }
 
-pub fn build_router() -> Router {
+pub async fn build_router() -> Result<Router, UpdaterError> {
+    let core = default_core().await?;
+    Ok(router_with_core(core))
+}
+
+fn router_with_core(core: UpdaterCore) -> Router {
+    let app_state = AppState { core };
+
+    let api = Router::new()
+        .route("/v1/update/stage", post(stage))
+        .route("/v1/update/commit", post(commit))
+        .route("/v1/update/rollback", post(rollback))
+        .route("/v1/update/status", get(status))
+        .with_state(app_state);
+
     Router::new()
         .route("/metrics", get(metrics))
-        .merge(health_router(SERVICE_NAME))
+        .merge(api)
+        .merge(health_routes())
         .layer(from_fn(track_http_metrics))
 }
 
@@ -92,4 +128,150 @@ async fn track_http_metrics(req: Request<Body>, next: Next) -> Response {
 
 pub fn init_for_tests() -> Result<(), ObsInitError> {
     ObsInit::init(SERVICE_NAME)
+}
+
+#[derive(Clone)]
+struct AppState {
+    core: UpdaterCore,
+}
+
+#[derive(Debug, Deserialize)]
+struct StageRequest {
+    artifact: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SlotResponse {
+    slot: Slot,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HealthResponseBody {
+    status: &'static str,
+}
+
+async fn stage(State(state): State<AppState>, Json(payload): Json<StageRequest>) -> Response {
+    match state.core.stage(payload.artifact).await {
+        Ok(slot) => (StatusCode::ACCEPTED, Json(SlotResponse { slot })).into_response(),
+        Err(err) => error_response(err),
+    }
+}
+
+async fn commit(State(state): State<AppState>) -> Response {
+    match state.core.commit_on_health().await {
+        Ok(slot) => (StatusCode::OK, Json(SlotResponse { slot })).into_response(),
+        Err(err) => error_response(err),
+    }
+}
+
+async fn rollback(State(state): State<AppState>) -> Response {
+    match state.core.rollback().await {
+        Ok(slot) => (StatusCode::OK, Json(SlotResponse { slot })).into_response(),
+        Err(err) => error_response(err),
+    }
+}
+
+async fn status(State(state): State<AppState>) -> Response {
+    let snapshot = state.core.state().await;
+    Json(snapshot).into_response()
+}
+
+async fn health_contract() -> Response {
+    Json(HealthResponseBody { status: "ok" }).into_response()
+}
+
+#[derive(Debug, Serialize)]
+struct InfoResponseBody {
+    service: &'static str,
+    version: &'static str,
+}
+
+fn health_routes() -> Router {
+    Router::new()
+        .route("/health", get(health_contract))
+        .route("/v1/health", get(health_contract))
+        .route("/info", get(info_contract))
+        .route("/v1/info", get(info_contract))
+}
+
+async fn info_contract() -> Response {
+    Json(InfoResponseBody {
+        service: SERVICE_NAME,
+        version: VERSION,
+    })
+    .into_response()
+}
+
+fn error_response(err: UpdaterError) -> Response {
+    let status = match &err {
+        UpdaterError::Stage(StageError::SlotBooting) => StatusCode::CONFLICT,
+        UpdaterError::Stage(_) => StatusCode::BAD_REQUEST,
+        UpdaterError::Commit(CommitError::NothingStaged) => StatusCode::BAD_REQUEST,
+        UpdaterError::Commit(CommitError::InvalidStageState) => StatusCode::CONFLICT,
+        UpdaterError::Rollback(_) => StatusCode::CONFLICT,
+        UpdaterError::HealthQuorumFailed => StatusCode::SERVICE_UNAVAILABLE,
+        UpdaterError::Store(_) | UpdaterError::Health(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+
+    (
+        status,
+        Json(ErrorResponse {
+            error: err.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+async fn default_core() -> Result<UpdaterCore, UpdaterError> {
+    let store = Arc::new(FileStateStore::new(DEFAULT_STATE_PATH));
+    let endpoints = health_endpoints_from_env();
+    let quorum = health_quorum_from_env(endpoints.len());
+    let health_client = Arc::new(HttpHealthClient::default());
+    let deadline = health_deadline_from_env();
+
+    UpdaterCore::new(store, health_client, endpoints, deadline, quorum).await
+}
+
+fn health_endpoints_from_env() -> Vec<String> {
+    std::env::var(HEALTH_ENDPOINTS_ENV)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|item| {
+                    let trimmed = item.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn health_deadline_from_env() -> Duration {
+    std::env::var(HEALTH_DEADLINE_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_HEALTH_DEADLINE)
+}
+
+fn health_quorum_from_env(default: usize) -> usize {
+    std::env::var(HEALTH_QUORUM_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+pub fn router_for_tests(core: UpdaterCore) -> Router {
+    router_with_core(core)
 }

--- a/services/updater/src/state.rs
+++ b/services/updater/src/state.rs
@@ -1,0 +1,235 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Hash)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Slot {
+    A,
+    B,
+}
+
+impl Slot {
+    pub const ALL: [Slot; 2] = [Slot::A, Slot::B];
+
+    pub fn other(self) -> Slot {
+        match self {
+            Slot::A => Slot::B,
+            Slot::B => Slot::A,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SlotState {
+    Inactive,
+    Staged,
+    Booting,
+    Active,
+    Bad,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SlotInfo {
+    pub state: SlotState,
+    pub artifact: Option<String>,
+    pub generation: u64,
+}
+
+impl SlotInfo {
+    fn new(state: SlotState) -> Self {
+        Self {
+            state,
+            artifact: None,
+            generation: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpdaterState {
+    pub generation: u64,
+    pub active: Option<Slot>,
+    pub previous_active: Option<Slot>,
+    pub staging: Option<Slot>,
+    pub last_failed: Option<Slot>,
+    pub slots: BTreeMap<Slot, SlotInfo>,
+}
+
+impl Default for UpdaterState {
+    fn default() -> Self {
+        let mut slots = BTreeMap::new();
+        slots.insert(Slot::A, SlotInfo::new(SlotState::Active));
+        slots.insert(Slot::B, SlotInfo::new(SlotState::Inactive));
+        Self {
+            generation: 0,
+            active: Some(Slot::A),
+            previous_active: None,
+            staging: None,
+            last_failed: None,
+            slots,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StageError {
+    #[error("no slot available for staging")]
+    NoAvailableSlot,
+    #[error("slot is currently booting and cannot be restaged")]
+    SlotBooting,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommitError {
+    #[error("no artifact is staged for commit")]
+    NothingStaged,
+    #[error("staging slot is not ready for commit")]
+    InvalidStageState,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RollbackError {
+    #[error("no previous active slot recorded for rollback")]
+    NoPreviousActive,
+    #[error("no failed slot recorded for rollback")]
+    NoFailedSlot,
+}
+
+impl UpdaterState {
+    pub fn stage(&mut self, artifact: String) -> Result<Slot, StageError> {
+        if let Some(slot) = self.staging {
+            let info = self
+                .slots
+                .get_mut(&slot)
+                .expect("staging slot must exist in state");
+            if info.state == SlotState::Booting {
+                return Err(StageError::SlotBooting);
+            }
+
+            if info.state == SlotState::Staged && info.artifact.as_deref() == Some(&artifact) {
+                return Ok(slot);
+            }
+
+            info.state = SlotState::Staged;
+            info.artifact = Some(artifact);
+            self.generation += 1;
+            info.generation = self.generation;
+            return Ok(slot);
+        }
+
+        let candidate = Slot::ALL
+            .into_iter()
+            .find(|slot| self.is_slot_available_for_stage(*slot))
+            .ok_or(StageError::NoAvailableSlot)?;
+
+        let info = self
+            .slots
+            .get_mut(&candidate)
+            .expect("candidate slot must exist in state");
+        info.state = SlotState::Staged;
+        info.artifact = Some(artifact);
+        self.generation += 1;
+        info.generation = self.generation;
+        self.staging = Some(candidate);
+
+        Ok(candidate)
+    }
+
+    fn is_slot_available_for_stage(&self, slot: Slot) -> bool {
+        if self.active == Some(slot) && self.slots[&slot].state == SlotState::Active {
+            return false;
+        }
+
+        matches!(
+            self.slots[&slot].state,
+            SlotState::Inactive | SlotState::Bad | SlotState::Staged
+        )
+    }
+
+    pub fn begin_commit(&mut self) -> Result<Slot, CommitError> {
+        let slot = self.staging.ok_or(CommitError::NothingStaged)?;
+        let info = self
+            .slots
+            .get_mut(&slot)
+            .expect("staging slot must exist in state");
+
+        match info.state {
+            SlotState::Staged => {
+                info.state = SlotState::Booting;
+                Ok(slot)
+            }
+            SlotState::Booting => Ok(slot),
+            _ => Err(CommitError::InvalidStageState),
+        }
+    }
+
+    pub fn finalize_commit(&mut self, slot: Slot) {
+        let previous_active = self.active;
+        if let Some(prev) = previous_active {
+            if prev != slot {
+                if let Some(info) = self.slots.get_mut(&prev) {
+                    info.state = SlotState::Inactive;
+                }
+            }
+        }
+
+        if let Some(info) = self.slots.get_mut(&slot) {
+            info.state = SlotState::Active;
+        }
+
+        self.previous_active = previous_active.filter(|prev| *prev != slot);
+        self.active = Some(slot);
+        self.staging = None;
+        self.last_failed = None;
+    }
+
+    pub fn fail_commit(&mut self, slot: Slot) {
+        if let Some(info) = self.slots.get_mut(&slot) {
+            info.state = SlotState::Bad;
+        }
+        self.last_failed = Some(slot);
+        self.staging = None;
+    }
+
+    pub fn mark_active_bad(&mut self) -> Option<Slot> {
+        let active = self.active?;
+        let info = self
+            .slots
+            .get_mut(&active)
+            .expect("active slot must exist in state");
+
+        if info.state != SlotState::Active {
+            return None;
+        }
+
+        info.state = SlotState::Bad;
+        self.active = None;
+        self.last_failed = Some(active);
+        Some(active)
+    }
+
+    pub fn rollback(&mut self) -> Result<Slot, RollbackError> {
+        let previous_active = self
+            .previous_active
+            .ok_or(RollbackError::NoPreviousActive)?;
+        let failed = self.last_failed.ok_or(RollbackError::NoFailedSlot)?;
+
+        if let Some(info) = self.slots.get_mut(&previous_active) {
+            info.state = SlotState::Active;
+        }
+        if let Some(info) = self.slots.get_mut(&failed) {
+            if info.state == SlotState::Bad {
+                info.state = SlotState::Inactive;
+            }
+        }
+
+        self.active = Some(previous_active);
+        self.previous_active = None;
+        self.last_failed = None;
+        self.staging = None;
+
+        Ok(previous_active)
+    }
+}

--- a/services/updater/src/store.rs
+++ b/services/updater/src/store.rs
@@ -1,0 +1,81 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+use crate::state::UpdaterState;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StateStoreError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to parse updater state: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+#[async_trait]
+pub trait StateStore: Send + Sync {
+    async fn load(&self) -> Result<Option<UpdaterState>, StateStoreError>;
+    async fn save(&self, state: &UpdaterState) -> Result<(), StateStoreError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FileStateStore {
+    path: PathBuf,
+}
+
+impl FileStateStore {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    async fn ensure_parent_dir(&self) -> Result<(), std::io::Error> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl StateStore for FileStateStore {
+    async fn load(&self) -> Result<Option<UpdaterState>, StateStoreError> {
+        match fs::read(&self.path).await {
+            Ok(bytes) => {
+                let state = serde_json::from_slice(&bytes)?;
+                Ok(Some(state))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(StateStoreError::Io(err)),
+        }
+    }
+
+    async fn save(&self, state: &UpdaterState) -> Result<(), StateStoreError> {
+        self.ensure_parent_dir().await?;
+        let json = serde_json::to_vec_pretty(state)?;
+        let mut file = fs::File::create(&self.path).await?;
+        file.write_all(&json).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MemoryStateStore {
+    pub state: tokio::sync::Mutex<Option<UpdaterState>>,
+}
+
+#[async_trait]
+impl StateStore for MemoryStateStore {
+    async fn load(&self) -> Result<Option<UpdaterState>, StateStoreError> {
+        Ok(self.state.lock().await.clone())
+    }
+
+    async fn save(&self, state: &UpdaterState) -> Result<(), StateStoreError> {
+        *self.state.lock().await = Some(state.clone());
+        Ok(())
+    }
+}

--- a/services/updater/tests/metrics.rs
+++ b/services/updater/tests/metrics.rs
@@ -6,7 +6,7 @@ use tokio::net::TcpListener;
 async fn metrics_endpoint_reports_uptime() {
     let _ = updater::init_for_tests();
 
-    let app = updater::build_router();
+    let app = updater::build_router().await.expect("build router");
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local addr");
 

--- a/services/updater/tests/state_machine.rs
+++ b/services/updater/tests/state_machine.rs
@@ -1,0 +1,212 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use updater::{HealthCheckError, HealthClient, MemoryStateStore, Slot, SlotState, UpdaterCore};
+
+#[derive(Debug, Clone)]
+struct TestStep {
+    action: Action,
+}
+
+#[derive(Debug, Clone)]
+enum Action {
+    Stage { artifact: &'static str },
+    Commit { expect_ok: bool },
+    MarkBad { expect_some: bool },
+    Rollback { expect_ok: bool },
+}
+
+#[derive(Debug)]
+struct TestCase {
+    name: &'static str,
+    steps: Vec<TestStep>,
+    health_results: Vec<bool>,
+    expected: Expected,
+}
+
+#[derive(Debug)]
+struct Expected {
+    active: Option<Slot>,
+    staging: Option<Slot>,
+    last_failed: Option<Slot>,
+    slots: Vec<(Slot, SlotState)>,
+}
+
+#[tokio::test]
+async fn state_machine_transitions() {
+    let cases = vec![
+        TestCase {
+            name: "happy_path_commit",
+            steps: vec![stage_step("artifact:v1"), commit_step(true)],
+            health_results: vec![true],
+            expected: Expected {
+                active: Some(Slot::B),
+                staging: None,
+                last_failed: None,
+                slots: vec![(Slot::A, SlotState::Inactive), (Slot::B, SlotState::Active)],
+            },
+        },
+        TestCase {
+            name: "commit_failure_marks_bad",
+            steps: vec![stage_step("artifact:v2"), commit_step(false)],
+            health_results: vec![false],
+            expected: Expected {
+                active: Some(Slot::A),
+                staging: None,
+                last_failed: Some(Slot::B),
+                slots: vec![(Slot::A, SlotState::Active), (Slot::B, SlotState::Bad)],
+            },
+        },
+        TestCase {
+            name: "mark_bad_then_rollback",
+            steps: vec![
+                stage_step("artifact:v3"),
+                commit_step(true),
+                TestStep {
+                    action: Action::MarkBad { expect_some: true },
+                },
+                TestStep {
+                    action: Action::Rollback { expect_ok: true },
+                },
+            ],
+            health_results: vec![true],
+            expected: Expected {
+                active: Some(Slot::A),
+                staging: None,
+                last_failed: None,
+                slots: vec![(Slot::A, SlotState::Active), (Slot::B, SlotState::Inactive)],
+            },
+        },
+    ];
+
+    for case in cases {
+        let store = Arc::new(MemoryStateStore::default()) as Arc<dyn updater::StateStore>;
+        let health_client = Arc::new(SequenceHealthClient::new(case.health_results.clone()));
+        let core = UpdaterCore::new(store, health_client, Vec::new(), Duration::from_secs(1), 0)
+            .await
+            .expect("core init");
+
+        run_steps(&case, &core).await;
+        assert_state(&case, &core).await;
+    }
+}
+
+fn stage_step(artifact: &'static str) -> TestStep {
+    TestStep {
+        action: Action::Stage { artifact },
+    }
+}
+
+fn commit_step(expect_ok: bool) -> TestStep {
+    TestStep {
+        action: Action::Commit { expect_ok },
+    }
+}
+
+async fn run_steps(case: &TestCase, core: &UpdaterCore) {
+    for step in &case.steps {
+        match step.action {
+            Action::Stage { artifact } => {
+                core.stage(artifact.to_string())
+                    .await
+                    .unwrap_or_else(|err| {
+                        panic!("{name}: stage failed: {err}", name = case.name, err = err)
+                    });
+            }
+            Action::Commit { expect_ok } => {
+                let result = core.commit_on_health().await;
+                assert_eq!(
+                    result.is_ok(),
+                    expect_ok,
+                    "{}: commit expectation",
+                    case.name
+                );
+            }
+            Action::MarkBad { expect_some } => {
+                let result = core.mark_bad().await.unwrap_or_else(|err| {
+                    panic!(
+                        "{name}: mark_bad failed: {err}",
+                        name = case.name,
+                        err = err
+                    )
+                });
+                assert_eq!(
+                    result.is_some(),
+                    expect_some,
+                    "{}: mark_bad expectation",
+                    case.name
+                );
+            }
+            Action::Rollback { expect_ok } => {
+                let result = core.rollback().await;
+                assert_eq!(
+                    result.is_ok(),
+                    expect_ok,
+                    "{}: rollback expectation",
+                    case.name
+                );
+            }
+        }
+    }
+}
+
+async fn assert_state(case: &TestCase, core: &UpdaterCore) {
+    let state = core.state().await;
+    assert_eq!(
+        state.active, case.expected.active,
+        "{}: active slot",
+        case.name
+    );
+    assert_eq!(
+        state.staging, case.expected.staging,
+        "{}: staging slot",
+        case.name
+    );
+    assert_eq!(
+        state.last_failed, case.expected.last_failed,
+        "{}: last failed",
+        case.name
+    );
+
+    for (slot, expected_state) in &case.expected.slots {
+        let info = state
+            .slots
+            .get(slot)
+            .unwrap_or_else(|| panic!("{}: missing slot {slot:?}", case.name));
+        assert_eq!(
+            info.state, *expected_state,
+            "{}: slot {slot:?} state",
+            case.name
+        );
+    }
+}
+
+#[derive(Debug)]
+struct SequenceHealthClient {
+    results: Mutex<VecDeque<bool>>,
+}
+
+impl SequenceHealthClient {
+    fn new(results: Vec<bool>) -> Self {
+        Self {
+            results: Mutex::new(results.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl HealthClient for SequenceHealthClient {
+    async fn wait_for_quorum(
+        &self,
+        _endpoints: &[String],
+        _deadline: Duration,
+        _quorum: usize,
+    ) -> Result<bool, HealthCheckError> {
+        let mut guard = self.results.lock().await;
+        Ok(guard.pop_front().unwrap_or(true))
+    }
+}


### PR DESCRIPTION
## Summary
- implement an A/B slot state machine with persisted state, health-aware commits, and rollback handling
- expose update API endpoints along with minimal /v1/health and info responses
- add table-driven tests covering staging, commit success/failure, mark-bad, and rollback flows

## Testing
- cargo test -p updater

------
https://chatgpt.com/codex/tasks/task_e_68d5fbe7de8c832f842cfe45d1a18c57