### PR TITLE
feat: add SBOM generation and build attestations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint test build e2e package sbom oas sdks sdk-c
+.PHONY: help fmt lint test build e2e package sbom attest oas sdks sdk-c
 
 BUILD_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo dev)
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -7,7 +7,7 @@ CARGO_ENV = BUILD_SHA=$(BUILD_SHA) BUILD_TIME=$(BUILD_TIME)
 FAST ?= 0
 
 help:
-	@echo "Available targets: fmt lint test build e2e package sbom oas sdks sdk-c"
+	@echo "Available targets: fmt lint test build e2e package sbom attest oas sdks sdk-c"
 
 fmt:
 	$(CARGO_ENV) cargo fmt --all
@@ -36,11 +36,14 @@ build:
 e2e:
 	@echo "e2e tests are not implemented yet"
 
-package:
-	os/images/build.sh
+package: sbom attest
+	OTA_SBOM_PATH=$(CURDIR)/dist/lokanos.sbom.json os/images/build.sh
 
 sbom:
-	@echo "SBOM generation is not implemented yet"
+	tools/sbom.sh
+
+attest:
+	tools/attest.sh
 
 oas:
 	@if [ "$(FAST)" = "1" ]; then \

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,18 @@
+# Release Compliance Checklist
+
+The following steps help ensure every LokanOS release captures basic supply-chain metadata.
+
+## Software Bill of Materials (SBOM)
+
+- Run `make sbom` to produce a CycloneDX JSON SBOM at `dist/lokanos.sbom.json`.
+- If [Syft](https://github.com/anchore/syft) is installed it will be used automatically; otherwise a minimal stub SBOM is emitted so downstream tooling always receives a valid document.
+- Verify the SBOM is archived alongside the OTA bundle when packaging releases.
+
+## Build Attestation
+
+- Run `make attest` to generate a provenance statement at `dist/lokanos.att.json`.
+- The attestation records the repository commit, UTC build timestamp, builder identity, and the list of tracked source inputs used for the build.
+
+## OTA Packaging
+
+- Run `make package` to create the OTA bundle. This target automatically regenerates the SBOM and attestation before invoking `os/images/build.sh` so the resulting `dist/` directory contains matching `*.sbom.json` and `*.att.json` artifacts for the release.

--- a/tools/attest.sh
+++ b/tools/attest.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+OUTPUT_PATH=${1:-$REPO_ROOT/dist/lokanos.att.json}
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+TMP_FILE=$(mktemp)
+
+cleanup() {
+  rm -f "$TMP_FILE"
+}
+trap cleanup EXIT
+
+BUILD_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+BUILDER_ID=${BUILDER_ID:-$(whoami 2>/dev/null || echo "unknown")@$(hostname 2>/dev/null || echo "unknown")}
+
+REPO_ROOT="$REPO_ROOT" BUILD_SHA="$BUILD_SHA" BUILD_TIME="$BUILD_TIME" BUILDER_ID="$BUILDER_ID" python3 - "$TMP_FILE" <<'PY'
+import json
+import os
+import sys
+import subprocess
+
+output_path = sys.argv[1]
+repo_root = os.environ["REPO_ROOT"]
+
+result = subprocess.run(
+    ["git", "-C", repo_root, "ls-files"],
+    check=True,
+    capture_output=True,
+    text=True,
+)
+inputs = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+attestation = {
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v1",
+    "subject": [
+        {"name": "repo", "digest": {"sha1": os.environ["BUILD_SHA"]}},
+    ],
+    "predicate": {
+        "buildType": "https://lokanos.dev/build",
+        "builder": {"id": os.environ["BUILDER_ID"]},
+        "buildStartedOn": os.environ["BUILD_TIME"],
+        "buildFinishedOn": os.environ["BUILD_TIME"],
+        "invocation": {
+            "configSource": {
+                "uri": os.environ["REPO_ROOT"],
+                "digest": {"sha1": os.environ["BUILD_SHA"]},
+            },
+            "parameters": {},
+        },
+        "materials": [
+            {"uri": f"git+file://{os.environ['REPO_ROOT']}", "digest": {"sha1": os.environ["BUILD_SHA"]}},
+        ],
+        "metadata": {
+            "inputs": inputs,
+        },
+    },
+}
+
+with open(output_path, "w", encoding="utf-8") as handle:
+    json.dump(attestation, handle, indent=2)
+    handle.write("\n")
+PY
+
+mv "$TMP_FILE" "$OUTPUT_PATH"
+trap - EXIT
+rm -f "$TMP_FILE"
+
+echo "Attestation written to $OUTPUT_PATH"

--- a/tools/sbom.sh
+++ b/tools/sbom.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+OUTPUT_PATH=${1:-$REPO_ROOT/dist/lokanos.sbom.json}
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+TMP_FILE=$(mktemp)
+
+cleanup() {
+  rm -f "$TMP_FILE"
+}
+trap cleanup EXIT
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+VERSION=$(git -C "$REPO_ROOT" describe --tags --dirty --always 2>/dev/null || echo "0.0.0-dev")
+
+if command -v syft >/dev/null 2>&1; then
+  syft "$REPO_ROOT" -o cyclonedx-json >"$TMP_FILE"
+else
+  TIMESTAMP="$TIMESTAMP" VERSION="$VERSION" python3 - "$TMP_FILE" <<'PY'
+import json
+import os
+import sys
+import uuid
+
+output_path = sys.argv[1]
+
+bom = {
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "serialNumber": f"urn:uuid:{uuid.uuid4()}",
+    "version": 1,
+    "metadata": {
+        "timestamp": os.environ["TIMESTAMP"],
+        "tools": [
+            {
+                "vendor": "LokanOS",
+                "name": "sbom.sh",
+                "version": "0.1",
+            }
+        ],
+        "component": {
+            "type": "application",
+            "bom-ref": "lokanos",
+            "name": "LokanOS",
+            "version": os.environ["VERSION"],
+        },
+    },
+    "components": [],
+}
+
+with open(output_path, "w", encoding="utf-8") as handle:
+    json.dump(bom, handle, indent=2)
+    handle.write("\n")
+PY
+fi
+
+mv "$TMP_FILE" "$OUTPUT_PATH"
+trap - EXIT
+rm -f "$TMP_FILE"
+
+echo "SBOM written to $OUTPUT_PATH"


### PR DESCRIPTION
## Summary
- add tooling to emit CycloneDX SBOMs and basic provenance attestations
- wire the new scripts into the Makefile and packaging flow so artifacts accompany OTA bundles
- document the release compliance checklist for SBOM and attestation steps

## Testing
- make sbom
- make attest

------
https://chatgpt.com/codex/tasks/task_e_68d608540b5c832f81c797557560acea